### PR TITLE
Suggestion: Skip connection status

### DIFF
--- a/ui/src/pages/deployment-details/deployment-details-form/section-source-images/section-source-images.tsx
+++ b/ui/src/pages/deployment-details/deployment-details-form/section-source-images/section-source-images.tsx
@@ -8,15 +8,12 @@ import { Button } from 'design-system/components/button/button'
 import { ImageCarousel } from 'design-system/components/image-carousel/image-carousel'
 import { InputValue } from 'design-system/components/input/input'
 import _ from 'lodash'
-import { Status } from 'pages/deployment-details/connection-status/types'
 import { useContext } from 'react'
 import { useForm } from 'react-hook-form'
 import { FormContext } from 'utils/formContext/formContext'
 import { isEmpty } from 'utils/isEmpty/isEmpty'
 import { STRING, translate } from 'utils/language'
 import { useSyncSectionStatus } from 'utils/useSyncSectionStatus'
-import { ConnectionStatus } from '../../connection-status/connection-status'
-import { useConnectionStatus } from '../../connection-status/useConnectionStatus'
 import styles from '../../styles.module.scss'
 import { config } from '../config'
 import { Section } from '../types'
@@ -47,10 +44,6 @@ export const SectionSourceImages = ({
 
   useSyncSectionStatus(Section.SourceImages, control)
 
-  const { status, refreshStatus, lastUpdated } = useConnectionStatus(
-    deployment?.path
-  )
-
   return (
     <form
       ref={formSectionRef}
@@ -65,32 +58,24 @@ export const SectionSourceImages = ({
         <div className={styles.sectionContent}>
           <div className={styles.sectionRow}>
             <FormField name="path" control={control} config={config} />
-            <ConnectionStatus
-              status={status}
-              onRefreshClick={refreshStatus}
-              lastUpdated={lastUpdated}
+          </div>
+
+          <div className={styles.sectionRow}>
+            <InputValue
+              label={translate(STRING.FIELD_LABEL_CAPTURES)}
+              value={deployment.numImages}
+            />
+            <InputValue
+              label={translate(STRING.FIELD_LABEL_EXAMPLE_CAPTURES)}
+              value={deployment.exampleCaptures.length}
             />
           </div>
-          {status === Status.Connected ? (
-            <>
-              <div className={styles.sectionRow}>
-                <InputValue
-                  label={translate(STRING.FIELD_LABEL_CAPTURES)}
-                  value={deployment.numImages}
-                />
-                <InputValue
-                  label={translate(STRING.FIELD_LABEL_EXAMPLE_CAPTURES)}
-                  value={deployment.exampleCaptures.length}
-                />
-              </div>
-              <div className={styles.exampleCapturesContainer}>
-                <ImageCarousel
-                  images={deployment.exampleCaptures}
-                  size={{ width: '100%', ratio: 16 / 9 }}
-                />
-              </div>
-            </>
-          ) : null}
+          <div className={styles.exampleCapturesContainer}>
+            <ImageCarousel
+              images={deployment.exampleCaptures}
+              size={{ width: '100%', ratio: 16 / 9 }}
+            />
+          </div>
         </div>
       </div>
       <div className={classNames(styles.section, styles.formActions)}>

--- a/ui/src/pages/deployment-details/deployment-details-info.tsx
+++ b/ui/src/pages/deployment-details/deployment-details-info.tsx
@@ -7,8 +7,6 @@ import { MultiMarkerMap } from 'design-system/map/multi-marker-map/multi-marker-
 import { MarkerPosition } from 'design-system/map/types'
 import { useMemo } from 'react'
 import { STRING, translate } from 'utils/language'
-import { ConnectionStatus } from './connection-status/connection-status'
-import { useConnectionStatus } from './connection-status/useConnectionStatus'
 import styles from './styles.module.scss'
 
 export const DeploymentDetailsInfo = ({
@@ -20,10 +18,6 @@ export const DeploymentDetailsInfo = ({
   title: string
   onEditClick: () => void
 }) => {
-  const { status, refreshStatus, lastUpdated } = useConnectionStatus(
-    deployment.path
-  )
-
   const markers = useMemo(
     () => [
       {
@@ -87,11 +81,6 @@ export const DeploymentDetailsInfo = ({
               <InputValue
                 label={translate(STRING.FIELD_LABEL_PATH)}
                 value={deployment.path}
-              />
-              <ConnectionStatus
-                status={status}
-                onRefreshClick={refreshStatus}
-                lastUpdated={lastUpdated}
               />
             </div>
             <div className={styles.sectionRow}>


### PR DESCRIPTION
Until we have hooked up connection status with BE, maybe it's better to hide this to avoid any confusions during testing? Merge or close this, depending on what you think @mihow :) I'm leaving hook and component in code, just removing the usage.