### PR TITLE
Link to a specific capture in session detail view

### DIFF
--- a/ui/src/data-services/hooks/useSessionDetails.ts
+++ b/ui/src/data-services/hooks/useSessionDetails.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
 import axios from 'axios'
 import { getFetchDetailsUrl } from 'data-services/utils'
+import _ from 'lodash'
 import { ServerEventDetails, SessionDetails } from '../models/session-details'
 
 const COLLECTION = 'events'
@@ -10,7 +11,7 @@ const convertServerRecord = (record: ServerEventDetails) =>
 
 export const useSessionDetails = (
   id: string,
-  occurrenceId?: string
+  params: { occurrence?: string; capture?: string }
 ): {
   session?: SessionDetails
   isLoading: boolean
@@ -20,7 +21,7 @@ export const useSessionDetails = (
   const fetchUrl = getFetchDetailsUrl({
     collection: COLLECTION,
     itemId: id,
-    queryParams: occurrenceId ? { occurrence: occurrenceId } : undefined,
+    queryParams: _.pickBy(params, (param) => param !== undefined),
   })
 
   const { data, isLoading, isFetching, error } = useQuery({

--- a/ui/src/data-services/models/occurrence-details.ts
+++ b/ui/src/data-services/models/occurrence-details.ts
@@ -29,6 +29,8 @@ export class OccurrenceDetails extends Occurrence {
 
     return {
       id,
+      captureId:
+        detection.capture !== undefined ? `${detection.capture_id}` : undefined,
       image: {
         src: detection.url,
         width: detection.width,

--- a/ui/src/data-services/models/occurrence-details.ts
+++ b/ui/src/data-services/models/occurrence-details.ts
@@ -30,7 +30,7 @@ export class OccurrenceDetails extends Occurrence {
     return {
       id,
       captureId:
-        detection.capture !== undefined ? `${detection.capture_id}` : undefined,
+        detection.capture !== undefined ? `${detection.capture}` : undefined,
       image: {
         src: detection.url,
         width: detection.width,

--- a/ui/src/data-services/models/occurrence-details.ts
+++ b/ui/src/data-services/models/occurrence-details.ts
@@ -30,7 +30,7 @@ export class OccurrenceDetails extends Occurrence {
     return {
       id,
       captureId:
-        detection.capture !== undefined ? `${detection.capture}` : undefined,
+        detection.capture?.id !== undefined ? `${detection.capture.id}` : undefined,
       image: {
         src: detection.url,
         width: detection.width,

--- a/ui/src/design-system/components/capture-list/capture-list.tsx
+++ b/ui/src/design-system/components/capture-list/capture-list.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 
-import { ReactNode, RefObject, useCallback, useEffect } from 'react'
+import { ReactNode, RefObject, useCallback } from 'react'
 import styles from './capture-list.module.scss'
 import { useIntersectionObserver } from './useIntersectionObserver'
 
@@ -37,13 +37,6 @@ export const CaptureList = ({
 
   const nextLoader = useIntersectionObserver({ onIntersect: _onNext })
   const prevLoader = useIntersectionObserver({ onIntersect: _onPrev })
-
-  useEffect(() => {
-    const scrollContainer = innerRef?.current
-    if (scrollContainer) {
-      scrollContainer.scrollTop = scrollContainer.scrollHeight
-    }
-  }, [innerRef?.current])
 
   return (
     <div ref={innerRef} className={styles.captures}>

--- a/ui/src/pages/occurrence-details/occurrence-details.tsx
+++ b/ui/src/pages/occurrence-details/occurrence-details.tsx
@@ -21,7 +21,20 @@ export const OccurrenceDetails = ({
       occurrence.detections.length
         ? occurrence.detections
             .map((id) => occurrence.getDetectionInfo(id))
-            .filter((item): item is BlueprintItem => !!item)
+            .filter(
+              (item): item is BlueprintItem & { captureId: string } => !!item
+            )
+            .map((item) => ({
+              ...item,
+              to: getRoute({
+                collection: 'sessions',
+                itemId: occurrence.sessionId,
+                filters: {
+                  occurrence: occurrence.id,
+                  capture: item.captureId,
+                },
+              }),
+            }))
         : [],
     [occurrence]
   )

--- a/ui/src/pages/session-details/playback/capture-picker/capture-picker.tsx
+++ b/ui/src/pages/session-details/playback/capture-picker/capture-picker.tsx
@@ -85,10 +85,11 @@ export const CapturePicker = ({
   }, [goToPrev, goToNext])
 
   // Scroll active element into view
-  const currentCaptureRef = activeCaptureId
-    ? captureRefs[activeCaptureId]?.current
-    : undefined
+  const _activeCaptureId = captures.length ? activeCaptureId : undefined
   useEffect(() => {
+    const currentCaptureRef = _activeCaptureId
+      ? captureRefs[_activeCaptureId]?.current
+      : undefined
     if (!currentCaptureRef) {
       return
     }
@@ -97,7 +98,7 @@ export const CapturePicker = ({
       block: 'nearest',
       inline: 'nearest',
     })
-  }, [currentCaptureRef])
+  }, [_activeCaptureId])
 
   if (!captures.length) {
     return null

--- a/ui/src/pages/session-details/playback/capture-picker/capture-picker.tsx
+++ b/ui/src/pages/session-details/playback/capture-picker/capture-picker.tsx
@@ -85,16 +85,19 @@ export const CapturePicker = ({
   }, [goToPrev, goToNext])
 
   // Scroll active element into view
+  const currentCaptureRef = activeCaptureId
+    ? captureRefs[activeCaptureId]?.current
+    : undefined
   useEffect(() => {
-    if (!activeCaptureId) {
+    if (!currentCaptureRef) {
       return
     }
-    captureRefs[activeCaptureId]?.current?.scrollIntoView({
+    currentCaptureRef.scrollIntoView({
       behavior: 'smooth',
       block: 'nearest',
       inline: 'nearest',
     })
-  }, [activeCaptureId])
+  }, [currentCaptureRef])
 
   if (!captures.length) {
     return null

--- a/ui/src/pages/session-details/playback/useActiveCapture.ts
+++ b/ui/src/pages/session-details/playback/useActiveCapture.ts
@@ -1,28 +1,50 @@
 import { Capture } from 'data-services/models/capture'
-import { useEffect, useState } from 'react'
+import { useEffect } from 'react'
+import { useSearchParams } from 'react-router-dom'
 import { useActiveOccurrences } from './useActiveOccurrences'
 
+const SEARCH_PARAM_KEY = 'capture'
+
+export const useActiveCaptureId = () => {
+  const [searchParams, setSearchParams] = useSearchParams()
+
+  const activeCaptureId = searchParams.get(SEARCH_PARAM_KEY) ?? undefined
+
+  const setActiveCaptureId = (captureId: string) => {
+    searchParams.delete(SEARCH_PARAM_KEY)
+    searchParams.set(SEARCH_PARAM_KEY, captureId)
+    setSearchParams(searchParams)
+  }
+
+  return { activeCaptureId, setActiveCaptureId }
+}
+
 export const useActiveCapture = (captures: Capture[]) => {
-  const [activeCapture, setActiveCapture] = useState<Capture>()
+  const { activeCaptureId, setActiveCaptureId } = useActiveCaptureId()
   const { activeOccurrences } = useActiveOccurrences()
+  const activeCapture = captures.find(
+    (capture) => capture.id === activeCaptureId
+  )
+  const setActiveCapture = (capture: Capture) => {
+    setActiveCaptureId(capture.id)
+  }
 
   useEffect(() => {
     // On load, decide what first capture to select
     if (!activeCapture && captures.length) {
       let firstCapture: Capture | undefined
 
-      // If we have one occurrence selected, search for the frame where it appears for the first time
+      // If we have an occurrence selected, search for the frame where it appears for the first time
       if (activeOccurrences.length === 1) {
-        const activeOccurrence = activeOccurrences[0]
         firstCapture = captures.find((c) =>
-          c.detections.find((d) => d.occurrenceId === activeOccurrence)
+          c.detections.find((d) => d.occurrenceId === activeOccurrences[0])
         )
       }
 
       // Fallback to first capture
       setActiveCapture(firstCapture ?? captures[0])
     }
-  }, [captures])
+  }, [captures, activeCapture])
 
   return { activeCapture, setActiveCapture }
 }

--- a/ui/src/pages/session-details/session-details.tsx
+++ b/ui/src/pages/session-details/session-details.tsx
@@ -6,6 +6,7 @@ import { useContext, useEffect } from 'react'
 import { useLocation, useParams } from 'react-router'
 import { BreadcrumbContext } from 'utils/breadcrumbContext'
 import { Playback } from './playback/playback'
+import { useActiveCaptureId } from './playback/useActiveCapture'
 import { useActiveOccurrences } from './playback/useActiveOccurrences'
 import styles from './session-details.module.scss'
 import { SessionInfo } from './session-info/session-info'
@@ -15,9 +16,10 @@ export const SessionDetails = () => {
   const { id } = useParams()
   const { setDetailBreadcrumb } = useContext(BreadcrumbContext)
   const { activeOccurrences } = useActiveOccurrences()
+  const { activeCaptureId } = useActiveCaptureId()
   const { session, isLoading, isFetching, error } = useSessionDetails(
     id as string,
-    activeOccurrences[0]
+    { capture: activeCaptureId, occurrence: activeOccurrences[0] }
   )
 
   useEffect(() => {

--- a/ui/src/utils/getRoute.ts
+++ b/ui/src/utils/getRoute.ts
@@ -12,6 +12,7 @@ type FilterType =
   | 'occurrences__deployment'
   | 'occurrences__event'
   | 'occurrence'
+  | 'capture'
 
 export const getRoute = ({
   collection,
@@ -21,7 +22,7 @@ export const getRoute = ({
 }: {
   collection: CollectionType
   itemId?: string
-  filters?: Partial<Record<FilterType, string>>
+  filters?: Partial<Record<FilterType, string | undefined>>
   keepSearchParams?: boolean
 }) => {
   let url = `/${collection}`
@@ -34,7 +35,9 @@ export const getRoute = ({
     keepSearchParams ? window.location.search : undefined
   )
   Object.entries(filters).forEach(([name, value]) => {
-    searchParams.set(name, value)
+    if (value !== undefined) {
+      searchParams.set(name, value)
+    }
   })
 
   const queryString = searchParams.toString()


### PR DESCRIPTION
Adding support for links to a specific capture in session detail view. I thought selections based on capture here was a nice approach (instead of using detections) because it also fits with how we present selections in UI.

If both occurrence and capture are part of the URL, the capture will be prioritised for the first selected capture (I think BE is not doing the same for the offset, but I think maybe it should?).

Example links:
- https://deploy-preview-195--ami-web.netlify.app/sessions/1?occurrence=12&capture=30
- https://deploy-preview-195--ami-web.netlify.app/sessions/1?capture=6
- https://deploy-preview-195--ami-web.netlify.app/sessions/1?capture=6&occurrence=12 (here I think maybe an offset matching the capture would be better in the response?)

Also preparing detections in occurrence details to link to a specific capture in session details with that occurrence selected. We don't have this info atm, but I hope for it to work if you just add the capture here @mihow:

<img width="1229" alt="Screenshot 2023-07-08 at 15 00 41" src="https://github.com/RolnickLab/ami-platform/assets/11680517/41e850c4-3c67-4500-a6fb-479f97e863cb">