### PR TITLE
Add some adjustments for small screens

### DIFF
--- a/ui/src/app.module.scss
+++ b/ui/src/app.module.scss
@@ -6,6 +6,7 @@
   background-color: $color-neutral-50;
   width: 100%;
   height: 100vh;
+  height: 100dvh;
   overflow-x: auto;
   overflow-y: auto;
 }

--- a/ui/src/app.module.scss
+++ b/ui/src/app.module.scss
@@ -5,6 +5,7 @@
   position: relative;
   background-color: $color-neutral-50;
   width: 100%;
+  min-width: 320px;
   height: 100vh;
   height: 100dvh;
   overflow-x: auto;

--- a/ui/src/app.module.scss
+++ b/ui/src/app.module.scss
@@ -5,7 +5,6 @@
   position: relative;
   background-color: $color-neutral-50;
   width: 100%;
-  min-width: 320px;
   height: 100vh;
   height: 100dvh;
   overflow-x: auto;

--- a/ui/src/components/blueprint-collection/blueprint-collection.module.scss
+++ b/ui/src/components/blueprint-collection/blueprint-collection.module.scss
@@ -1,5 +1,6 @@
 @import 'design-system/variables/colors.scss';
 @import 'design-system/variables/typography.scss';
+@import 'design-system/variables/variables.scss';
 
 .blueprint {
   display: flex;
@@ -67,5 +68,13 @@
     box-sizing: border-box;
     @include paragraph-x-small();
     background-color: $color-generic-white;
+  }
+}
+
+@media only screen and (max-width: $small-screen-breakpoint) {
+  .blueprint {
+    &.empty {
+      display: none;
+    }
   }
 }

--- a/ui/src/components/blueprint-collection/blueprint-collection.tsx
+++ b/ui/src/components/blueprint-collection/blueprint-collection.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import { Icon, IconType } from 'design-system/components/icon/icon'
 import { useState } from 'react'
 import { Link } from 'react-router-dom'
@@ -13,7 +14,11 @@ export interface BlueprintItem {
 }
 
 export const BlueprintCollection = ({ items }: { items: BlueprintItem[] }) => (
-  <div className={styles.blueprint}>
+  <div
+    className={classNames(styles.blueprint, {
+      [styles.empty]: items.length === 0,
+    })}
+  >
     {items.map((item) =>
       item.to ? (
         <Link key={item.id} to={item.to} className={styles.blueprintItem}>

--- a/ui/src/components/fetch-info/fetch-info.module.scss
+++ b/ui/src/components/fetch-info/fetch-info.module.scss
@@ -1,5 +1,6 @@
 @import 'design-system/variables/colors.scss';
 @import 'design-system/variables/typography.scss';
+@import 'design-system/variables/variables.scss';
 
 .wrapper {
   height: 32px;
@@ -16,5 +17,11 @@
     @include paragraph-x-small();
     font-weight: 600;
     color: $color-neutral-500;
+  }
+}
+
+@media only screen and (max-width: $small-screen-breakpoint) {
+  .wrapper {
+    display: none;
   }
 }

--- a/ui/src/components/filter-settings/filter-settings.module.scss
+++ b/ui/src/components/filter-settings/filter-settings.module.scss
@@ -4,6 +4,7 @@
 .wrapper {
   padding: 20px;
   min-width: 180px;
+  box-sizing: border-box;
 }
 
 .description {

--- a/ui/src/components/header/header.module.scss
+++ b/ui/src/components/header/header.module.scss
@@ -33,9 +33,11 @@
 @media only screen and (max-width: $small-screen-breakpoint) {
   .header {
     padding: 0;
+    height: auto;
   }
 
   .topBar {
-    padding-left: 16px;
+    height: auto;
+    padding: 8px 16px;
   }
 }

--- a/ui/src/design-system/components/dialog/dialog.module.scss
+++ b/ui/src/design-system/components/dialog/dialog.module.scss
@@ -32,6 +32,7 @@ $dialog-padding-medium: 32px;
   transform: translate(-50%, -50%);
   max-width: calc(100% - (2 * $dialog-padding-large));
   height: calc(100vh - (2 * $dialog-padding-large));
+  height: calc(100dvh - (2 * $dialog-padding-large));
   border-radius: 4px;
   background-color: $color-generic-white;
   box-shadow: 0px 4px 16px rgba(0, 0, 0, 0.1);
@@ -40,6 +41,10 @@ $dialog-padding-medium: 32px;
 
   &:focus-visible {
     box-shadow: 0 0 0 2px $color-generic-black;
+  }
+
+  &.loading {
+    display: none;
   }
 }
 
@@ -109,13 +114,19 @@ $dialog-padding-medium: 32px;
   .dialog {
     width: 100%;
     height: 100vh;
+    height: 100dvh;
     max-width: 100%;
     max-height: 100vh;
+    max-height: 100dvh;
     border-radius: 0;
     border: none;
   }
 
   .dialogContent {
     height: 100%;
+  }
+
+  .dialogHeader {
+    padding: 16px 32px 16px 16px;
   }
 }

--- a/ui/src/design-system/components/dialog/dialog.tsx
+++ b/ui/src/design-system/components/dialog/dialog.tsx
@@ -1,4 +1,5 @@
 import * as Dialog from '@radix-ui/react-dialog'
+import classNames from 'classnames'
 import { ReactNode } from 'react'
 import { Icon, IconType } from '../icon/icon'
 import { LoadingSpinner } from '../loading-spinner/loading-spinner'
@@ -41,7 +42,10 @@ const Content = ({
         </div>
       ) : null}
     </Dialog.Overlay>
-    <Dialog.Content className={styles.dialog} onOpenAutoFocus={onOpenAutoFocus}>
+    <Dialog.Content
+      className={classNames(styles.dialog, { [styles.loading]: isLoading })}
+      onOpenAutoFocus={onOpenAutoFocus}
+    >
       <div className={styles.dialogContent}>{children}</div>
       <Dialog.Close className={styles.dialogClose} aria-label={ariaCloselabel}>
         <Icon type={IconType.Close} size={12} />

--- a/ui/src/design-system/components/navigation/navigation-bar.module.scss
+++ b/ui/src/design-system/components/navigation/navigation-bar.module.scss
@@ -93,6 +93,10 @@
     }
   }
 
+  .item {
+    padding: 8px 12px;
+  }
+
   .itemTitle,
   .itemCount {
     display: none;

--- a/ui/src/design-system/components/table/basic-table-cell/basic-table-cell.module.scss
+++ b/ui/src/design-system/components/table/basic-table-cell/basic-table-cell.module.scss
@@ -22,3 +22,9 @@
     }
   }
 }
+
+@media only screen and (max-width: $small-screen-breakpoint) {
+  .tableCell {
+    padding: 12px 16px;
+  }
+}

--- a/ui/src/design-system/components/table/column-settings/column-settings.module.scss
+++ b/ui/src/design-system/components/table/column-settings/column-settings.module.scss
@@ -4,6 +4,7 @@
 .wrapper {
   padding: 20px;
   min-width: 180px;
+  box-sizing: border-box;
 }
 
 .description {

--- a/ui/src/design-system/components/table/table-header/table-header.module.scss
+++ b/ui/src/design-system/components/table/table-header/table-header.module.scss
@@ -1,5 +1,6 @@
 @import 'design-system/variables/colors.scss';
 @import 'design-system/variables/typography.scss';
+@import 'design-system/variables/variables.scss';
 
 .tableHeader {
   all: unset;
@@ -69,4 +70,10 @@
   height: 0;
   padding: 0;
   overflow: hidden;
+}
+
+@media only screen and (max-width: $small-screen-breakpoint) {
+  .content {
+    padding: 12px 16px;
+  }
 }

--- a/ui/src/design-system/map/multi-marker-map/multi-marker-map.tsx
+++ b/ui/src/design-system/map/multi-marker-map/multi-marker-map.tsx
@@ -1,3 +1,4 @@
+import { LoadingSpinner } from 'design-system/components/loading-spinner/loading-spinner'
 import * as L from 'leaflet'
 import { useEffect, useMemo, useRef } from 'react'
 import { MapContainer, Marker, Popup, TileLayer } from 'react-leaflet'
@@ -6,13 +7,12 @@ import {
   DEFAULT_ZOOM,
   MAX_BOUNDS,
   MIN_ZOOM,
-  setup,
   TILE_LAYER_URL,
+  setup,
 } from '../config'
 import { MinimapControl } from '../minimap-control'
 import styles from '../styles.module.scss'
 import { MarkerPosition } from '../types'
-import { LoadingSpinner } from 'design-system/components/loading-spinner/loading-spinner'
 
 setup()
 
@@ -54,6 +54,7 @@ export const MultiMarkerMap = ({
     <MapContainer
       center={bounds.getCenter()}
       className={styles.mapContainer}
+      dragging={false}
       maxBounds={MAX_BOUNDS}
       minZoom={MIN_ZOOM}
       ref={mapRef}

--- a/ui/src/design-system/variables/typography.scss
+++ b/ui/src/design-system/variables/typography.scss
@@ -1,9 +1,16 @@
+@import 'design-system/variables/variables.scss';
+
 @mixin heading-6 {
   font-family: 'AzoSans';
   font-style: normal;
   font-weight: 600;
   font-size: 20px;
   line-height: 28px;
+
+  @media only screen and (max-width: $small-screen-breakpoint) {
+    font-size: 18px;
+    line-height: 24px;
+  }
 }
 
 @mixin heading-5 {
@@ -13,15 +20,25 @@
   font-size: 24px;
   line-height: 32px;
   letter-spacing: -0.02em;
+
+  @media only screen and (max-width: $small-screen-breakpoint) {
+    font-size: 20px;
+    line-height: 28px;
+  }
 }
 
 @mixin heading-4-italic {
   font-family: 'AzoSans';
   font-style: normal;
   font-weight: 400;
-  font-size: 24px;
-  line-height: 32px;
+  font-size: 28px;
+  line-height: 36px;
   font-style: italic;
+
+  @media only screen and (max-width: $small-screen-breakpoint) {
+    font-size: 24px;
+    line-height: 32px;
+  }
 }
 
 @mixin paragraph-xx-small {
@@ -38,6 +55,11 @@
   font-weight: 400;
   font-size: 12px;
   line-height: 20px;
+
+  @media only screen and (max-width: $small-screen-breakpoint) {
+    font-size: 10px;
+    line-height: 18px;
+  }
 }
 
 @mixin paragraph-small {
@@ -46,6 +68,11 @@
   font-weight: 400;
   font-size: 14px;
   line-height: 20px;
+
+  @media only screen and (max-width: $small-screen-breakpoint) {
+    font-size: 12px;
+    line-height: 20px;
+  }
 }
 
 @mixin paragraph-medium {
@@ -54,6 +81,11 @@
   font-weight: 400;
   font-size: 16px;
   line-height: 24px;
+
+  @media only screen and (max-width: $small-screen-breakpoint) {
+    font-size: 14px;
+    line-height: 20px;
+  }
 }
 
 @mixin paragraph-large {
@@ -62,6 +94,11 @@
   font-weight: 400;
   font-size: 18px;
   line-height: 28px;
+
+  @media only screen and (max-width: $small-screen-breakpoint) {
+    font-size: 16px;
+    line-height: 24px;
+  }
 }
 
 // Not present in Figma

--- a/ui/src/pages/deployment-details/styles.module.scss
+++ b/ui/src/pages/deployment-details/styles.module.scss
@@ -64,7 +64,32 @@
 }
 
 @media only screen and (max-width: $small-screen-breakpoint) {
+  .section {
+    margin: 16px;
+
+    &:not(:first-child) {
+      padding-top: 16px;
+    }
+  }
+
+  .sectionTitle {
+    margin: 0 0 16px;
+  }
+
+  .sectionContent {
+    gap: 16px;
+
+    &:not(:last-child) {
+      margin-bottom: 16px;
+    }
+  }
+
   .sectionRow {
     grid-template-columns: 1fr;
+    gap: 16px;
+  }
+
+  .exampleCapturesContainer {
+    margin: 16px 0;
   }
 }

--- a/ui/src/pages/job-details/job-details.module.scss
+++ b/ui/src/pages/job-details/job-details.module.scss
@@ -30,8 +30,7 @@
 .sectionFields {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  column-gap: 32px;
-  row-gap: 32px;
+  gap: 32px;
 }
 
 .sectionStatus {
@@ -46,9 +45,13 @@
 }
 
 @media only screen and (max-width: $small-screen-breakpoint) {
+  .section {
+    margin: 16px;
+  }
+
   .sectionFields {
     grid-template-columns: 1fr;
-    gap: 32px;
+    gap: 16px;
   }
 
   .sectionStatus {

--- a/ui/src/pages/occurrences/occurrences.module.scss
+++ b/ui/src/pages/occurrences/occurrences.module.scss
@@ -32,9 +32,13 @@
   transform: rotate(90deg);
 }
 
-.sidebar {
-  width: 262px;
-  background-color: $color-neutral-200;
-  height: 400px;
-  margin-right: 16px;
+@media only screen and (max-width: $small-screen-breakpoint) {
+  .tableContent,
+  .galleryContent {
+    padding: 0;
+  }
+
+  .settingsWrapper {
+    top: 14px;
+  }
 }

--- a/ui/src/pages/overview/overview.module.scss
+++ b/ui/src/pages/overview/overview.module.scss
@@ -6,6 +6,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  min-height: 320px;
 }
 
 // About
@@ -16,10 +17,7 @@
   border: 1px solid $color-neutral-100;
   background: $color-generic-white;
   overflow: hidden;
-
-  &:not(:last-child) {
-    margin-bottom: 32px;
-  }
+  margin: 0 0 16px;
 }
 
 .aboutImage {
@@ -101,7 +99,23 @@
 }
 
 @media only screen and (max-width: $small-screen-breakpoint) {
+  .about {
+    margin: 0 0 16px;
+  }
+
+  .aboutInfo {
+    padding: 16px;
+  }
+
   .plots {
     grid-template-columns: 1fr;
+  }
+
+  .plotsContainer {
+    padding: 16px;
+  }
+
+  .label {
+    margin-bottom: 16px;
   }
 }

--- a/ui/src/pages/session-details/playback/playback.module.scss
+++ b/ui/src/pages/session-details/playback/playback.module.scss
@@ -1,4 +1,5 @@
 @import 'design-system/variables/colors.scss';
+@import 'design-system/variables/variables.scss';
 
 .wrapper {
   display: flex;
@@ -13,4 +14,20 @@
   min-width: 320px;
   background-color: $color-neutral-800;
   position: relative;
+}
+
+@media only screen and (max-width: $small-screen-breakpoint) {
+  .wrapper {
+    flex-direction: column;
+  }
+
+  .playbackFrame {
+    width: 100%;
+  }
+
+  .capturePicker {
+    width: 100%;
+    min-width: auto;
+    height: 240px;
+  }
 }

--- a/ui/src/pages/session-details/session-details.module.scss
+++ b/ui/src/pages/session-details/session-details.module.scss
@@ -69,7 +69,15 @@
 }
 
 @media only screen and (max-width: $small-screen-breakpoint) {
+  .playbackWrapper {
+    margin-bottom: 16px;
+  }
+
   .details {
     grid-template-columns: 1fr;
+  }
+
+  .detailsContent {
+    padding: 16px;
   }
 }

--- a/ui/src/pages/session-details/session-details.tsx
+++ b/ui/src/pages/session-details/session-details.tsx
@@ -65,10 +65,9 @@ export const SessionDetails = () => {
           </div>
         </div>
         {session.summaryData.map((summary, index) => (
-          <div className={styles.detailsContainer}>
+          <div key={index} className={styles.detailsContainer}>
             <div className={styles.detailsContent}>
               <Plot
-                key={index}
                 title={summary.title}
                 data={summary.data}
                 orientation={summary.orientation}

--- a/ui/src/pages/sessions/sessions.module.scss
+++ b/ui/src/pages/sessions/sessions.module.scss
@@ -1,3 +1,5 @@
+@import 'design-system/variables/variables.scss';
+
 .infoWrapper {
   position: absolute;
   top: 0;
@@ -27,4 +29,15 @@
   left: 0;
   z-index: 1;
   transform: rotate(90deg);
+}
+
+@media only screen and (max-width: $small-screen-breakpoint) {
+  .tableContent,
+  .galleryContent {
+    padding: 0;
+  }
+
+  .settingsWrapper {
+    top: 14px;
+  }
 }

--- a/ui/src/pages/species/species.module.scss
+++ b/ui/src/pages/species/species.module.scss
@@ -1,3 +1,5 @@
+@import 'design-system/variables/variables.scss';
+
 .infoWrapper {
   position: absolute;
   top: 0;
@@ -19,4 +21,11 @@
   display: flex;
   align-items: flex-start;
   padding: 16px 0;
+}
+
+@media only screen and (max-width: $small-screen-breakpoint) {
+  .tableContent,
+  .galleryContent {
+    padding: 0;
+  }
 }


### PR DESCRIPTION
I realised the mobile version has gotten minimal attention last week! Here comes some quick tweaks:
- Fix broken session detail view
- Consider the dynamic view port size when we want "full height"
- Adjust paddings and margins here and there (32px -> 16px)
- Adjust typography (go down one step in size and line height)

Still a lot of improvements to made for mobile devices, for example find an alternative to our hover interactions and make table views even more compact? Also the session detail might need some alternative designs? I hope this will take care of most urgent issues though :)