### PR TITLE
Tweak project map

### DIFF
--- a/ui/src/design-system/map/config.ts
+++ b/ui/src/design-system/map/config.ts
@@ -10,7 +10,7 @@ export const TILE_LAYER_URL =
 
 export const DEFAULT_ZOOM = 10
 
-export const MIN_ZOOM = 2
+export const MIN_ZOOM = 1
 
 export const MAX_BOUNDS = new L.LatLngBounds([-90, -180], [90, 180])
 

--- a/ui/src/design-system/map/minimap-control.tsx
+++ b/ui/src/design-system/map/minimap-control.tsx
@@ -8,13 +8,13 @@ import {
   useMap,
   useMapEvent,
 } from 'react-leaflet'
-import { MAX_BOUNDS, setup, TILE_LAYER_URL } from './config'
+import { MAX_BOUNDS, TILE_LAYER_URL, setup } from './config'
 
 setup()
 
 const MINIMAP_BOUNDS_OPTIONS = { weight: 1 }
 const MINIMAP_STYLE = { height: 80, width: 80 }
-const MINIMAP_ZOOM = 1
+const MINIMAP_ZOOM = 0
 
 const MinimapBounds = ({
   parentMap,

--- a/ui/src/design-system/map/multi-marker-map/multi-marker-map.tsx
+++ b/ui/src/design-system/map/multi-marker-map/multi-marker-map.tsx
@@ -54,7 +54,6 @@ export const MultiMarkerMap = ({
     <MapContainer
       center={bounds.getCenter()}
       className={styles.mapContainer}
-      dragging={false}
       maxBounds={MAX_BOUNDS}
       minZoom={MIN_ZOOM}
       ref={mapRef}


### PR DESCRIPTION
Some small tweaks to the project map:
- Enable map dragging
- Tweak min zoom value (we do set initial zoom and bounds based on marker positions, but in order to fit markers on different continents we had to decrease min zoom value)

**Before:**
<img width="396" alt="Screenshot 2023-08-21 at 12 11 44" src="https://github.com/RolnickLab/ami-platform/assets/11680517/a6ecbd6a-9e3d-4bc6-ba43-620692a82e8c">

**After:**
<img width="397" alt="Screenshot 2023-08-21 at 12 12 11" src="https://github.com/RolnickLab/ami-platform/assets/11680517/a05c3a37-9a21-4036-9b21-3d4a50e56821">
