### PR TITLE
Move "create" permission to the collection/list view

### DIFF
--- a/ami/main/api/pagination.py
+++ b/ami/main/api/pagination.py
@@ -1,0 +1,12 @@
+from rest_framework.pagination import LimitOffsetPagination
+
+from ami.main.api.permissions import add_collection_level_permissions
+
+
+class LimitOffsetPaginationWithPermissions(LimitOffsetPagination):
+    def get_paginated_response(self, data):
+        paginated_response = super().get_paginated_response(data=data)
+        paginated_response.data = add_collection_level_permissions(
+            user=self.request.user, response_data=paginated_response.data
+        )
+        return paginated_response

--- a/ami/main/api/permissions.py
+++ b/ami/main/api/permissions.py
@@ -1,0 +1,29 @@
+def add_object_level_permissions(user, response_data) -> dict:
+    """
+    Add placeholder permissions to detail views and nested objects.
+
+    If the user is logged in, they can edit any object type.
+    If the user is a superuser, they can delete any object type.
+
+    @TODO @IMPORTANT At least check if they are the owner of the project.
+    """
+    permissions = response_data.get("user_permissions", set())
+    if user and user.is_authenticated:
+        permissions.update(["update"])
+        if user.is_superuser:
+            permissions.update(["delete"])
+    response_data["user_permissions"] = permissions
+    return response_data
+
+
+def add_collection_level_permissions(user, response_data) -> dict:
+    """
+    Add placeholder permissions to list view responses.
+
+    If the user is logged in, they can create new objects of any type.
+    """
+    permissions = response_data.get("user_permissions", set())
+    if user and user.is_authenticated:
+        permissions.add("create")
+    response_data["user_permissions"] = permissions
+    return response_data

--- a/ami/main/api/serializers.py
+++ b/ami/main/api/serializers.py
@@ -20,6 +20,7 @@ from ..models import (
     SourceImage,
     Taxon,
 )
+from .permissions import add_object_level_permissions
 
 
 def reverse_with_params(viewname: str, args=None, kwargs=None, request=None, params: dict = {}, **extra) -> str:
@@ -47,18 +48,7 @@ class DefaultSerializer(serializers.HyperlinkedModelSerializer):
     def to_representation(self, instance):
         data = super().to_representation(instance)
 
-        # Add placeholder object-level permissions to each object
-        # For this placeholder, everyone can read,
-        # logged-in users can edit, and superusers can delete
-        permissions = set()
-        if hasattr(instance, "user_permissions"):
-            permissions.update(instance.user_permissions)
-        elif self.context["request"].user.is_authenticated:
-            permissions.update(["update", "create"])
-            if self.context["request"].user.is_superuser:
-                permissions.update(["delete"])
-        data["user_permissions"] = permissions
-        return data
+        return add_object_level_permissions(self.context.get("request").user, data)
 
 
 class UserSerializer(DefaultSerializer):

--- a/ami/main/models.py
+++ b/ami/main/models.py
@@ -534,7 +534,7 @@ class Deployment(BaseModel):
             self.save()
 
     def save(self, *args, update_calculated_fields=True, **kwargs):
-        if update_calculated_fields:
+        if self.pk and update_calculated_fields:
             self.update_calculated_fields()
             if self.project:
                 self.update_children()

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -312,7 +312,7 @@ REST_FRAMEWORK = {
     "DEFAULT_PERMISSION_CLASSES": ("rest_framework.permissions.IsAuthenticatedOrReadOnly",),
     # "DEFAULT_PERMISSION_CLASSES": ("rest_framework.permissions.AllowAny",),
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
-    "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.LimitOffsetPagination",
+    "DEFAULT_PAGINATION_CLASS": "ami.main.api.pagination.LimitOffsetPaginationWithPermissions",
     "PAGE_SIZE": 10,
     "DEFAULT_FILTER_BACKENDS": ["django_filters.rest_framework.DjangoFilterBackend"],
     "DEFAULT_VERSIONING_CLASS": "rest_framework.versioning.NamespaceVersioning",

--- a/local.yml
+++ b/local.yml
@@ -31,7 +31,6 @@ services:
     volumes:
       - ami_local_postgres_data:/var/lib/postgresql/data
       - ami_local_postgres_data_backups:/backups
-      - ./compose/production/postgres/postgresql.conf:/var/lib/postgresql/data/postgresql.conf
     env_file:
       - ./.envs/.local/.postgres
 

--- a/production.yml
+++ b/production.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3"
 
 volumes:
   production_postgres_data: {}
@@ -28,6 +28,7 @@ services:
     volumes:
       - production_postgres_data:/var/lib/postgresql/data
       - production_postgres_data_backups:/backups
+      - ./compose/production/postgres/postgresql.conf:/var/lib/postgresql/data/postgresql.conf
     env_file:
       - ./.envs/.production/.postgres
 
@@ -41,9 +42,9 @@ services:
     volumes:
       - production_traefik:/etc/traefik/acme
     ports:
-      - '0.0.0.0:80:80'
-      - '0.0.0.0:443:443'
-      - '0.0.0.0:5555:5555'
+      - "0.0.0.0:80:80"
+      - "0.0.0.0:443:443"
+      - "0.0.0.0:5555:5555"
 
   redis:
     image: redis:6


### PR DESCRIPTION
Moved the "create" permission to paginated list views. This only applies to views of a particular object type like "Deployment" or "Project". But that is the majority of our views!

![image](https://github.com/RolnickLab/ami-platform/assets/158175/68f8cc09-b356-4b96-aa65-66e367318693)
