### PR TITLE
Update how dimensions for imported images are set

### DIFF
--- a/ami/main/tests.py
+++ b/ami/main/tests.py
@@ -110,7 +110,7 @@ class TestImageGrouping(TestCase):
         assert remaining_events.count() == 0
 
     def test_setting_image_dimensions(self):
-        from ami.main.models import set_dimensions_from_first_image
+        from ami.main.models import set_dimensions_for_collection
 
         image_width, image_height = 100, 100
 
@@ -122,7 +122,7 @@ class TestImageGrouping(TestCase):
             assert first_image is not None
             first_image.width, first_image.height = image_width, image_height
             first_image.save()
-            set_dimensions_from_first_image(event=event)
+            set_dimensions_for_collection(event=event)
 
             for capture in event.captures.all():
                 # print(capture.path, capture.width, capture.height)


### PR DESCRIPTION
- Use existing image dimensions if they exist
- Don't fail if can't determine image dimensions from source image
- Stub out a different approach for using a property on Deployment instead of the first image

@TODO do we need width/height fields after we start making and using thumbs?