### PR TITLE
Refactor handling of app routes

### DIFF
--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -22,7 +22,7 @@ import {
   BreadcrumbContext,
   BreadcrumbContextProvider,
 } from 'utils/breadcrumbContext'
-import { getAppRoute } from 'utils/getAppRoute'
+import { APP_ROUTES } from 'utils/constants'
 import { UserContextProvider } from 'utils/user/userContext'
 import styles from './app.module.scss'
 
@@ -96,7 +96,7 @@ const ProjectContainer = () => {
   useEffect(() => {
     setProjectBreadcrumb({
       title: projectDetails.project?.name ?? '',
-      path: getAppRoute({ projectId: projectId as string }),
+      path: APP_ROUTES.PROJECT_DETAILS({ projectId: projectId as string }),
     })
 
     return () => {

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -22,7 +22,7 @@ import {
   BreadcrumbContext,
   BreadcrumbContextProvider,
 } from 'utils/breadcrumbContext'
-import { getRoute } from 'utils/getRoute'
+import { getAppRoute } from 'utils/getAppRoute'
 import { UserContextProvider } from 'utils/user/userContext'
 import styles from './app.module.scss'
 
@@ -96,7 +96,7 @@ const ProjectContainer = () => {
   useEffect(() => {
     setProjectBreadcrumb({
       title: projectDetails.project?.name ?? '',
-      path: getRoute({ projectId: projectId as string }),
+      path: getAppRoute({ projectId: projectId as string }),
     })
 
     return () => {

--- a/ui/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/ui/src/components/breadcrumbs/breadcrumbs.tsx
@@ -3,7 +3,7 @@ import { Icon, IconTheme, IconType } from 'design-system/components/icon/icon'
 import { Fragment, useContext, useEffect } from 'react'
 import { Link } from 'react-router-dom'
 import { Breadcrumb, BreadcrumbContext } from 'utils/breadcrumbContext'
-import { LINKS } from 'utils/constants'
+import { APP_ROUTES } from 'utils/constants'
 import { STRING, translate } from 'utils/language'
 import styles from './breadcrumbs.module.scss'
 
@@ -34,7 +34,7 @@ export const Breadcrumbs = ({
   }, [navItems, activeNavItemId])
 
   const breadcrumbs = [
-    { title: translate(STRING.NAV_ITEM_PROJECTS), path: LINKS.HOME },
+    { title: translate(STRING.NAV_ITEM_PROJECTS), path: APP_ROUTES.HOME },
     projectBreadcrumb,
     mainBreadcrumb,
     detailBreadcrumb,

--- a/ui/src/components/header/header.tsx
+++ b/ui/src/components/header/header.tsx
@@ -3,7 +3,7 @@ import { useLogout } from 'data-services/hooks/auth/useLogout'
 import { usePages } from 'data-services/hooks/pages/usePages'
 import { Button, ButtonTheme } from 'design-system/components/button/button'
 import { Link, useNavigate } from 'react-router-dom'
-import { LINKS } from 'utils/constants'
+import { APP_ROUTES } from 'utils/constants'
 import { useUser } from 'utils/user/userContext'
 import ami from './ami.png'
 import styles from './header.module.scss'
@@ -33,7 +33,7 @@ export const Header = () => {
         <Button
           label="Sign up"
           theme={ButtonTheme.Plain}
-          onClick={() => navigate(LINKS.SIGN_UP)}
+          onClick={() => navigate(APP_ROUTES.SIGN_UP)}
         />
         {user.loggedIn ? (
           <>
@@ -49,7 +49,7 @@ export const Header = () => {
           <Button
             label="Login"
             theme={ButtonTheme.Plain}
-            onClick={() => navigate(LINKS.LOGIN)}
+            onClick={() => navigate(APP_ROUTES.LOGIN)}
           />
         )}
       </div>

--- a/ui/src/pages/auth/login.tsx
+++ b/ui/src/pages/auth/login.tsx
@@ -6,7 +6,7 @@ import { parseServerError } from 'data-services/utils'
 import { Button, ButtonTheme } from 'design-system/components/button/button'
 import { useForm } from 'react-hook-form'
 import { Link, useLocation, useNavigate } from 'react-router-dom'
-import { LINKS } from 'utils/constants'
+import { APP_ROUTES } from 'utils/constants'
 import styles from './auth.module.scss'
 
 interface LoginFormValues {
@@ -33,7 +33,7 @@ export const Login = () => {
   const { state } = useLocation()
   const navigate = useNavigate()
   const { login, isLoading, error } = useLogin({
-    onSuccess: () => navigate(LINKS.HOME),
+    onSuccess: () => navigate(APP_ROUTES.HOME),
   })
   const { control, handleSubmit } = useForm<LoginFormValues>({
     defaultValues: { email: state?.email ?? '', password: '' },
@@ -65,14 +65,14 @@ export const Login = () => {
           </p>
         ) : null}
         <p className={styles.text}>
-          No account yet? <Link to={LINKS.SIGN_UP}>Sign up</Link>
+          No account yet? <Link to={APP_ROUTES.SIGN_UP}>Sign up</Link>
         </p>
         <p className={classNames(styles.text, styles.divider)}>OR</p>
         <Button
           label="View public projects"
           type="button"
           theme={ButtonTheme.Default}
-          onClick={() => navigate(LINKS.HOME)}
+          onClick={() => navigate(APP_ROUTES.HOME)}
         />
       </form>
     </>

--- a/ui/src/pages/auth/sign-up.tsx
+++ b/ui/src/pages/auth/sign-up.tsx
@@ -8,7 +8,7 @@ import { Icon, IconTheme, IconType } from 'design-system/components/icon/icon'
 import { useEffect, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { Link, useNavigate } from 'react-router-dom'
-import { LINKS } from 'utils/constants'
+import { APP_ROUTES } from 'utils/constants'
 import styles from './auth.module.scss'
 
 interface SignUpFormValues {
@@ -106,7 +106,7 @@ export const SignUp = () => {
             <span>Already have an account?</span>
           )}
           <Link
-            to={LINKS.LOGIN}
+            to={APP_ROUTES.LOGIN}
             state={isSuccess ? { email: signedUpEmail } : undefined}
           >
             Login
@@ -117,7 +117,7 @@ export const SignUp = () => {
           label="View public projects"
           type="button"
           theme={ButtonTheme.Default}
-          onClick={() => navigate(LINKS.HOME)}
+          onClick={() => navigate(APP_ROUTES.HOME)}
         />
       </form>
     </>

--- a/ui/src/pages/deployment-details/deployment-details-dialog.tsx
+++ b/ui/src/pages/deployment-details/deployment-details-dialog.tsx
@@ -4,7 +4,7 @@ import { DeploymentDetails } from 'data-services/models/deployment-details'
 import * as Dialog from 'design-system/components/dialog/dialog'
 import { useEffect, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
-import { getRoute } from 'utils/getRoute'
+import { getAppRoute } from 'utils/getAppRoute'
 import { STRING, translate } from 'utils/language'
 import { DeploymentDetailsForm } from './deployment-details-form/deployment-details-form'
 import { DeploymentDetailsInfo } from './deployment-details-info'
@@ -19,7 +19,7 @@ export const DeploymentDetailsDialog = ({ id }: { id: string }) => {
       open={!!id}
       onOpenChange={() =>
         navigate(
-          getRoute({
+          getAppRoute({
             projectId: projectId as string,
             collection: 'deployments',
             keepSearchParams: true,

--- a/ui/src/pages/deployment-details/deployment-details-dialog.tsx
+++ b/ui/src/pages/deployment-details/deployment-details-dialog.tsx
@@ -4,6 +4,7 @@ import { DeploymentDetails } from 'data-services/models/deployment-details'
 import * as Dialog from 'design-system/components/dialog/dialog'
 import { useEffect, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
+import { APP_ROUTES } from 'utils/constants'
 import { getAppRoute } from 'utils/getAppRoute'
 import { STRING, translate } from 'utils/language'
 import { DeploymentDetailsForm } from './deployment-details-form/deployment-details-form'
@@ -20,8 +21,7 @@ export const DeploymentDetailsDialog = ({ id }: { id: string }) => {
       onOpenChange={() =>
         navigate(
           getAppRoute({
-            projectId: projectId as string,
-            collection: 'deployments',
+            to: APP_ROUTES.DEPLOYMENTS({ projectId: projectId as string }),
             keepSearchParams: true,
           })
         )

--- a/ui/src/pages/deployments/deployment-columns.tsx
+++ b/ui/src/pages/deployments/deployment-columns.tsx
@@ -6,115 +6,111 @@ import {
   TextAlign,
 } from 'design-system/components/table/types'
 import { Link } from 'react-router-dom'
-import { getRoute } from 'utils/getRoute'
+import { getAppRoute } from 'utils/getAppRoute'
 import { STRING, translate } from 'utils/language'
 
 export const columns: (projectId: string) => TableColumn<Deployment>[] = (
   projectId: string
 ) => [
-    {
-      id: 'deployment',
-      name: translate(STRING.FIELD_LABEL_DEPLOYMENT),
-      sortField: 'name',
-      renderCell: (item: Deployment) => (
-        <Link
-          to={getRoute({
-            projectId,
-            collection: 'deployments',
-            itemId: item.id,
-            keepSearchParams: true,
-          })}
-        >
-          <BasicTableCell value={item.name} theme={CellTheme.Primary} />
-        </Link>
-      ),
+  {
+    id: 'deployment',
+    name: translate(STRING.FIELD_LABEL_DEPLOYMENT),
+    sortField: 'name',
+    renderCell: (item: Deployment) => (
+      <Link
+        to={getAppRoute({
+          projectId,
+          collection: 'deployments',
+          itemId: item.id,
+          keepSearchParams: true,
+        })}
+      >
+        <BasicTableCell value={item.name} theme={CellTheme.Primary} />
+      </Link>
+    ),
+  },
+  {
+    id: 'sessions',
+    name: translate(STRING.FIELD_LABEL_SESSIONS),
+    sortField: 'numEvents',
+    styles: {
+      textAlign: TextAlign.Right,
     },
-    {
-      id: 'sessions',
-      name: translate(STRING.FIELD_LABEL_SESSIONS),
-      sortField: 'numEvents',
-      styles: {
-        textAlign: TextAlign.Right,
-      },
-      renderCell: (item: Deployment) => (
-        <Link
-          to={getRoute({
-            projectId,
-            collection: 'sessions',
-            filters: { deployment: item.id },
-          })}
-        >
-          <BasicTableCell value={item.numEvents} theme={CellTheme.Primary} />
-        </Link>
-      ),
+    renderCell: (item: Deployment) => (
+      <Link
+        to={getAppRoute({
+          projectId,
+          collection: 'sessions',
+          filters: { deployment: item.id },
+        })}
+      >
+        <BasicTableCell value={item.numEvents} theme={CellTheme.Primary} />
+      </Link>
+    ),
+  },
+  {
+    id: 'captures',
+    name: translate(STRING.FIELD_LABEL_CAPTURES),
+    sortField: 'numImages',
+    styles: {
+      textAlign: TextAlign.Right,
     },
-    {
-      id: 'captures',
-      name: translate(STRING.FIELD_LABEL_CAPTURES),
-      sortField: 'numImages',
-      styles: {
-        textAlign: TextAlign.Right,
-      },
-      renderCell: (item: Deployment) => <BasicTableCell value={item.numImages} />,
+    renderCell: (item: Deployment) => <BasicTableCell value={item.numImages} />,
+  },
+  {
+    id: 'occurrences',
+    name: translate(STRING.FIELD_LABEL_OCCURRENCES),
+    sortField: 'numOccurrences',
+    styles: {
+      textAlign: TextAlign.Right,
     },
-    {
-      id: 'occurrences',
-      name: translate(STRING.FIELD_LABEL_OCCURRENCES),
-      sortField: 'numOccurrences',
-      styles: {
-        textAlign: TextAlign.Right,
-      },
-      renderCell: (item: Deployment) => (
-        <Link
-          to={getRoute({
-            projectId,
-            collection: 'occurrences',
-            filters: { deployment: item.id },
-          })}
-        >
-          <BasicTableCell value={item.numOccurrences} theme={CellTheme.Primary} />
-        </Link>
-      ),
+    renderCell: (item: Deployment) => (
+      <Link
+        to={getAppRoute({
+          projectId,
+          collection: 'occurrences',
+          filters: { deployment: item.id },
+        })}
+      >
+        <BasicTableCell value={item.numOccurrences} theme={CellTheme.Primary} />
+      </Link>
+    ),
+  },
+  {
+    id: 'species',
+    name: translate(STRING.FIELD_LABEL_SPECIES),
+    sortField: 'numSpecies',
+    styles: {
+      textAlign: TextAlign.Right,
     },
-    {
-      id: 'species',
-      name: translate(STRING.FIELD_LABEL_SPECIES),
-      sortField: 'numSpecies',
-      styles: {
-        textAlign: TextAlign.Right,
-      },
-      renderCell: (item: Deployment) => (
-        <Link
-          to={getRoute({
-            projectId,
-            collection: 'species',
-            filters: { occurrences__deployment: item.id },
-          })}
-        >
-          <BasicTableCell value={item.numSpecies} theme={CellTheme.Primary} />
-        </Link>
-      ),
+    renderCell: (item: Deployment) => (
+      <Link
+        to={getAppRoute({
+          projectId,
+          collection: 'species',
+          filters: { occurrences__deployment: item.id },
+        })}
+      >
+        <BasicTableCell value={item.numSpecies} theme={CellTheme.Primary} />
+      </Link>
+    ),
+  },
+  {
+    id: 'firstDate',
+    name: translate(STRING.FIELD_LABEL_FIRST_DATE),
+    sortField: 'firstDate',
+    styles: {
+      textAlign: TextAlign.Right,
     },
-    {
-      id: 'firstDate',
-      name: translate(STRING.FIELD_LABEL_FIRST_DATE),
-      sortField: 'firstDate',
-      styles: {
-        textAlign: TextAlign.Right,
-      },
-      renderCell: (item: Deployment) => (
-        <BasicTableCell value={item.firstDate} />
-      ),
+    renderCell: (item: Deployment) => <BasicTableCell value={item.firstDate} />,
+  },
+  {
+    id: 'lastDate',
+    name: translate(STRING.FIELD_LABEL_LAST_DATE),
+    sortField: 'lastDate',
+    styles: {
+      textAlign: TextAlign.Right,
     },
-    {
-      id: 'lastDate',
-      name: translate(STRING.FIELD_LABEL_LAST_DATE),
-      sortField: 'lastDate',
-      styles: {
-        textAlign: TextAlign.Right,
-      },
-      renderCell: (item: Deployment) => (
-        <BasicTableCell value={item.lastDate} />
-      ),
-    },
-  ]
+    renderCell: (item: Deployment) => <BasicTableCell value={item.lastDate} />,
+  },
+]

--- a/ui/src/pages/deployments/deployment-columns.tsx
+++ b/ui/src/pages/deployments/deployment-columns.tsx
@@ -6,6 +6,7 @@ import {
   TextAlign,
 } from 'design-system/components/table/types'
 import { Link } from 'react-router-dom'
+import { APP_ROUTES } from 'utils/constants'
 import { getAppRoute } from 'utils/getAppRoute'
 import { STRING, translate } from 'utils/language'
 
@@ -19,9 +20,10 @@ export const columns: (projectId: string) => TableColumn<Deployment>[] = (
     renderCell: (item: Deployment) => (
       <Link
         to={getAppRoute({
-          projectId,
-          collection: 'deployments',
-          itemId: item.id,
+          to: APP_ROUTES.DEPLOYMENT_DETAILS({
+            projectId,
+            deploymentId: item.id,
+          }),
           keepSearchParams: true,
         })}
       >
@@ -39,8 +41,7 @@ export const columns: (projectId: string) => TableColumn<Deployment>[] = (
     renderCell: (item: Deployment) => (
       <Link
         to={getAppRoute({
-          projectId,
-          collection: 'sessions',
+          to: APP_ROUTES.SESSIONS({ projectId }),
           filters: { deployment: item.id },
         })}
       >
@@ -67,8 +68,7 @@ export const columns: (projectId: string) => TableColumn<Deployment>[] = (
     renderCell: (item: Deployment) => (
       <Link
         to={getAppRoute({
-          projectId,
-          collection: 'occurrences',
+          to: APP_ROUTES.OCCURRENCES({ projectId }),
           filters: { deployment: item.id },
         })}
       >
@@ -86,8 +86,7 @@ export const columns: (projectId: string) => TableColumn<Deployment>[] = (
     renderCell: (item: Deployment) => (
       <Link
         to={getAppRoute({
-          projectId,
-          collection: 'species',
+          to: APP_ROUTES.SPECIES({ projectId }),
           filters: { occurrences__deployment: item.id },
         })}
       >

--- a/ui/src/pages/jobs/jobs-columns.tsx
+++ b/ui/src/pages/jobs/jobs-columns.tsx
@@ -4,7 +4,7 @@ import { BasicTableCell } from 'design-system/components/table/basic-table-cell/
 import { StatusTableCell } from 'design-system/components/table/status-table-cell/status-table-cell'
 import { CellTheme, TableColumn } from 'design-system/components/table/types'
 import { Link } from 'react-router-dom'
-import { getRoute } from 'utils/getRoute'
+import { getAppRoute } from 'utils/getAppRoute'
 import { STRING, translate } from 'utils/language'
 
 export const columns: (projectId: string) => TableColumn<Job>[] = (
@@ -15,7 +15,7 @@ export const columns: (projectId: string) => TableColumn<Job>[] = (
     name: 'Job',
     renderCell: (item: Job) => (
       <Link
-        to={getRoute({
+        to={getAppRoute({
           projectId,
           collection: 'jobs',
           itemId: item.id,

--- a/ui/src/pages/jobs/jobs-columns.tsx
+++ b/ui/src/pages/jobs/jobs-columns.tsx
@@ -4,6 +4,7 @@ import { BasicTableCell } from 'design-system/components/table/basic-table-cell/
 import { StatusTableCell } from 'design-system/components/table/status-table-cell/status-table-cell'
 import { CellTheme, TableColumn } from 'design-system/components/table/types'
 import { Link } from 'react-router-dom'
+import { APP_ROUTES } from 'utils/constants'
 import { getAppRoute } from 'utils/getAppRoute'
 import { STRING, translate } from 'utils/language'
 
@@ -16,9 +17,7 @@ export const columns: (projectId: string) => TableColumn<Job>[] = (
     renderCell: (item: Job) => (
       <Link
         to={getAppRoute({
-          projectId,
-          collection: 'jobs',
-          itemId: item.id,
+          to: APP_ROUTES.JOB_DETAILS({ projectId, jobId: item.id }),
           keepSearchParams: true,
         })}
       >

--- a/ui/src/pages/jobs/jobs.tsx
+++ b/ui/src/pages/jobs/jobs.tsx
@@ -7,7 +7,7 @@ import { Table } from 'design-system/components/table/table/table'
 import { Error } from 'pages/error/error'
 import { JobDetails } from 'pages/job-details/job-details'
 import { useNavigate, useParams } from 'react-router-dom'
-import { getRoute } from 'utils/getRoute'
+import { getAppRoute } from 'utils/getAppRoute'
 import { STRING, translate } from 'utils/language'
 import { usePagination } from 'utils/usePagination'
 import { columns } from './jobs-columns'
@@ -61,7 +61,7 @@ const JobDetailsDialog = ({ id }: { id: string }) => {
       open={!!id}
       onOpenChange={() =>
         navigate(
-          getRoute({
+          getAppRoute({
             projectId: projectId as string,
             collection: 'jobs',
             keepSearchParams: true,

--- a/ui/src/pages/jobs/jobs.tsx
+++ b/ui/src/pages/jobs/jobs.tsx
@@ -7,6 +7,7 @@ import { Table } from 'design-system/components/table/table/table'
 import { Error } from 'pages/error/error'
 import { JobDetails } from 'pages/job-details/job-details'
 import { useNavigate, useParams } from 'react-router-dom'
+import { APP_ROUTES } from 'utils/constants'
 import { getAppRoute } from 'utils/getAppRoute'
 import { STRING, translate } from 'utils/language'
 import { usePagination } from 'utils/usePagination'
@@ -62,8 +63,7 @@ const JobDetailsDialog = ({ id }: { id: string }) => {
       onOpenChange={() =>
         navigate(
           getAppRoute({
-            projectId: projectId as string,
-            collection: 'jobs',
+            to: APP_ROUTES.JOBS({ projectId: projectId as string }),
             keepSearchParams: true,
           })
         )

--- a/ui/src/pages/occurrence-details/occurrence-details.tsx
+++ b/ui/src/pages/occurrence-details/occurrence-details.tsx
@@ -7,6 +7,7 @@ import { InfoBlock } from 'design-system/components/info-block/info-block'
 import * as Tabs from 'design-system/components/tabs/tabs'
 import { useMemo } from 'react'
 import { Link, useParams } from 'react-router-dom'
+import { APP_ROUTES } from 'utils/constants'
 import { getAppRoute } from 'utils/getAppRoute'
 import { STRING, translate } from 'utils/language'
 import styles from './occurrence-details.module.scss'
@@ -29,9 +30,10 @@ export const OccurrenceDetails = ({
             .map((item) => ({
               ...item,
               to: getAppRoute({
-                projectId: projectId as string,
-                collection: 'sessions',
-                itemId: occurrence.sessionId,
+                to: APP_ROUTES.SESSION_DETAILS({
+                  projectId: projectId as string,
+                  sessionId: occurrence.sessionId,
+                }),
                 filters: {
                   occurrence: occurrence.id,
                   capture: item.captureId,
@@ -46,19 +48,16 @@ export const OccurrenceDetails = ({
     {
       label: translate(STRING.FIELD_LABEL_DEPLOYMENT),
       value: occurrence.deploymentLabel,
-      to: getAppRoute({
-        projectId: projectId as string,
-        collection: 'deployments',
-        itemId: occurrence.deploymentId,
-      }),
+      to: APP_ROUTES.DEPLOYMENTS({ projectId: projectId as string }),
     },
     {
       label: translate(STRING.FIELD_LABEL_SESSION),
       value: occurrence.sessionLabel,
       to: getAppRoute({
-        projectId: projectId as string,
-        collection: 'sessions',
-        itemId: occurrence.sessionId,
+        to: APP_ROUTES.SESSION_DETAILS({
+          projectId: projectId as string,
+          sessionId: occurrence.sessionId,
+        }),
         filters: { occurrence: occurrence.id },
       }),
     },
@@ -84,10 +83,9 @@ export const OccurrenceDetails = ({
     <div className={styles.wrapper}>
       <div className={styles.header}>
         <Link
-          to={getAppRoute({
+          to={APP_ROUTES.SPECIES_DETAILS({
             projectId: projectId as string,
-            collection: 'species',
-            itemId: occurrence.determinationId,
+            speciesId: occurrence.determinationId,
           })}
         >
           <span className={styles.title}>{occurrence.determinationLabel}</span>

--- a/ui/src/pages/occurrence-details/occurrence-details.tsx
+++ b/ui/src/pages/occurrence-details/occurrence-details.tsx
@@ -7,7 +7,7 @@ import { InfoBlock } from 'design-system/components/info-block/info-block'
 import * as Tabs from 'design-system/components/tabs/tabs'
 import { useMemo } from 'react'
 import { Link, useParams } from 'react-router-dom'
-import { getRoute } from 'utils/getRoute'
+import { getAppRoute } from 'utils/getAppRoute'
 import { STRING, translate } from 'utils/language'
 import styles from './occurrence-details.module.scss'
 
@@ -28,7 +28,7 @@ export const OccurrenceDetails = ({
             )
             .map((item) => ({
               ...item,
-              to: getRoute({
+              to: getAppRoute({
                 projectId: projectId as string,
                 collection: 'sessions',
                 itemId: occurrence.sessionId,
@@ -46,7 +46,7 @@ export const OccurrenceDetails = ({
     {
       label: translate(STRING.FIELD_LABEL_DEPLOYMENT),
       value: occurrence.deploymentLabel,
-      to: getRoute({
+      to: getAppRoute({
         projectId: projectId as string,
         collection: 'deployments',
         itemId: occurrence.deploymentId,
@@ -55,7 +55,7 @@ export const OccurrenceDetails = ({
     {
       label: translate(STRING.FIELD_LABEL_SESSION),
       value: occurrence.sessionLabel,
-      to: getRoute({
+      to: getAppRoute({
         projectId: projectId as string,
         collection: 'sessions',
         itemId: occurrence.sessionId,
@@ -84,7 +84,7 @@ export const OccurrenceDetails = ({
     <div className={styles.wrapper}>
       <div className={styles.header}>
         <Link
-          to={getRoute({
+          to={getAppRoute({
             projectId: projectId as string,
             collection: 'species',
             itemId: occurrence.determinationId,

--- a/ui/src/pages/occurrences/occurrence-columns.tsx
+++ b/ui/src/pages/occurrences/occurrence-columns.tsx
@@ -7,7 +7,7 @@ import {
   TableColumn,
 } from 'design-system/components/table/types'
 import { Link } from 'react-router-dom'
-import { getRoute } from 'utils/getRoute'
+import { getAppRoute } from 'utils/getAppRoute'
 import { STRING, translate } from 'utils/language'
 
 export const columns: (projectId: string) => TableColumn<Occurrence>[] = (
@@ -35,7 +35,7 @@ export const columns: (projectId: string) => TableColumn<Occurrence>[] = (
     name: translate(STRING.FIELD_LABEL_ID),
     renderCell: (item: Occurrence) => (
       <Link
-        to={getRoute({
+        to={getAppRoute({
           projectId,
           collection: 'occurrences',
           itemId: item.id,
@@ -55,7 +55,7 @@ export const columns: (projectId: string) => TableColumn<Occurrence>[] = (
     name: translate(STRING.FIELD_LABEL_DEPLOYMENT),
     renderCell: (item: Occurrence) => (
       <Link
-        to={getRoute({
+        to={getAppRoute({
           projectId,
           collection: 'deployments',
           itemId: item.deploymentId,
@@ -73,7 +73,7 @@ export const columns: (projectId: string) => TableColumn<Occurrence>[] = (
     name: translate(STRING.FIELD_LABEL_SESSION),
     renderCell: (item: Occurrence) => (
       <Link
-        to={getRoute({
+        to={getAppRoute({
           projectId,
           collection: 'sessions',
           itemId: item.sessionId,

--- a/ui/src/pages/occurrences/occurrence-columns.tsx
+++ b/ui/src/pages/occurrences/occurrence-columns.tsx
@@ -7,6 +7,7 @@ import {
   TableColumn,
 } from 'design-system/components/table/types'
 import { Link } from 'react-router-dom'
+import { APP_ROUTES } from 'utils/constants'
 import { getAppRoute } from 'utils/getAppRoute'
 import { STRING, translate } from 'utils/language'
 
@@ -36,9 +37,10 @@ export const columns: (projectId: string) => TableColumn<Occurrence>[] = (
     renderCell: (item: Occurrence) => (
       <Link
         to={getAppRoute({
-          projectId,
-          collection: 'occurrences',
-          itemId: item.id,
+          to: APP_ROUTES.OCCURRENCE_DETAILS({
+            projectId,
+            occurrenceId: item.id,
+          }),
           keepSearchParams: true,
         })}
       >
@@ -55,10 +57,9 @@ export const columns: (projectId: string) => TableColumn<Occurrence>[] = (
     name: translate(STRING.FIELD_LABEL_DEPLOYMENT),
     renderCell: (item: Occurrence) => (
       <Link
-        to={getAppRoute({
+        to={APP_ROUTES.DEPLOYMENT_DETAILS({
           projectId,
-          collection: 'deployments',
-          itemId: item.deploymentId,
+          deploymentId: item.deploymentId,
         })}
       >
         <BasicTableCell
@@ -72,13 +73,7 @@ export const columns: (projectId: string) => TableColumn<Occurrence>[] = (
     id: 'session',
     name: translate(STRING.FIELD_LABEL_SESSION),
     renderCell: (item: Occurrence) => (
-      <Link
-        to={getAppRoute({
-          projectId,
-          collection: 'sessions',
-          itemId: item.sessionId,
-        })}
-      >
+      <Link to={APP_ROUTES.SESSION_DETAILS({ projectId, sessionId: item.id })}>
         <BasicTableCell value={item.sessionLabel} theme={CellTheme.Primary} />
       </Link>
     ),

--- a/ui/src/pages/occurrences/occurrence-gallery.tsx
+++ b/ui/src/pages/occurrences/occurrence-gallery.tsx
@@ -2,6 +2,7 @@ import { Gallery } from 'components/gallery/gallery'
 import { Occurrence } from 'data-services/models/occurrence'
 import { useMemo } from 'react'
 import { useParams } from 'react-router-dom'
+import { APP_ROUTES } from 'utils/constants'
 import { getAppRoute } from 'utils/getAppRoute'
 
 export const OccurrenceGallery = ({
@@ -21,9 +22,10 @@ export const OccurrenceGallery = ({
         subTitle: `(${o.determinationScore})`,
         title: o.determinationLabel,
         to: getAppRoute({
-          projectId: projectId as string,
-          collection: 'occurrences',
-          itemId: o.id,
+          to: APP_ROUTES.OCCURRENCE_DETAILS({
+            projectId: projectId as string,
+            occurrenceId: o.id,
+          }),
           keepSearchParams: true,
         }),
       })),

--- a/ui/src/pages/occurrences/occurrence-gallery.tsx
+++ b/ui/src/pages/occurrences/occurrence-gallery.tsx
@@ -2,7 +2,7 @@ import { Gallery } from 'components/gallery/gallery'
 import { Occurrence } from 'data-services/models/occurrence'
 import { useMemo } from 'react'
 import { useParams } from 'react-router-dom'
-import { getRoute } from 'utils/getRoute'
+import { getAppRoute } from 'utils/getAppRoute'
 
 export const OccurrenceGallery = ({
   occurrences = [],
@@ -20,7 +20,7 @@ export const OccurrenceGallery = ({
         image: o.images[0],
         subTitle: `(${o.determinationScore})`,
         title: o.determinationLabel,
-        to: getRoute({
+        to: getAppRoute({
           projectId: projectId as string,
           collection: 'occurrences',
           itemId: o.id,

--- a/ui/src/pages/occurrences/occurrences.tsx
+++ b/ui/src/pages/occurrences/occurrences.tsx
@@ -13,6 +13,7 @@ import { Error } from 'pages/error/error'
 import { OccurrenceDetails } from 'pages/occurrence-details/occurrence-details'
 import { useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
+import { APP_ROUTES } from 'utils/constants'
 import { getAppRoute } from 'utils/getAppRoute'
 import { STRING, translate } from 'utils/language'
 import { useFilters } from 'utils/useFilters'
@@ -121,8 +122,7 @@ const OccurrenceDetailsDialog = ({ id }: { id: string }) => {
       onOpenChange={() =>
         navigate(
           getAppRoute({
-            projectId: projectId as string,
-            collection: 'occurrences',
+            to: APP_ROUTES.OCCURRENCES({ projectId: projectId as string }),
             keepSearchParams: true,
           })
         )

--- a/ui/src/pages/occurrences/occurrences.tsx
+++ b/ui/src/pages/occurrences/occurrences.tsx
@@ -13,7 +13,7 @@ import { Error } from 'pages/error/error'
 import { OccurrenceDetails } from 'pages/occurrence-details/occurrence-details'
 import { useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
-import { getRoute } from 'utils/getRoute'
+import { getAppRoute } from 'utils/getAppRoute'
 import { STRING, translate } from 'utils/language'
 import { useFilters } from 'utils/useFilters'
 import { usePagination } from 'utils/usePagination'
@@ -120,7 +120,7 @@ const OccurrenceDetailsDialog = ({ id }: { id: string }) => {
       open={!!id}
       onOpenChange={() =>
         navigate(
-          getRoute({
+          getAppRoute({
             projectId: projectId as string,
             collection: 'occurrences',
             keepSearchParams: true,

--- a/ui/src/pages/overview/deployments-map/deployments-map-popup-content.tsx
+++ b/ui/src/pages/overview/deployments-map/deployments-map-popup-content.tsx
@@ -1,6 +1,6 @@
 import { Deployment } from 'data-services/models/deployment'
 import { Link, useParams } from 'react-router-dom'
-import { getRoute } from 'utils/getRoute'
+import { getAppRoute } from 'utils/getAppRoute'
 import { STRING, translate } from 'utils/language'
 
 export const DeploymentsMapPopupContent = ({
@@ -14,7 +14,7 @@ export const DeploymentsMapPopupContent = ({
     <>
       <p>
         <Link
-          to={getRoute({
+          to={getAppRoute({
             projectId: projectId as string,
             collection: 'deployments',
             itemId: deployment.id,
@@ -33,7 +33,8 @@ export const DeploymentsMapPopupContent = ({
         </span>
         <br />
         <span>
-          {translate(STRING.FIELD_LABEL_OCCURRENCES)}: {deployment.numOccurrences}
+          {translate(STRING.FIELD_LABEL_OCCURRENCES)}:{' '}
+          {deployment.numOccurrences}
         </span>
       </p>
     </>

--- a/ui/src/pages/overview/deployments-map/deployments-map-popup-content.tsx
+++ b/ui/src/pages/overview/deployments-map/deployments-map-popup-content.tsx
@@ -1,6 +1,6 @@
 import { Deployment } from 'data-services/models/deployment'
 import { Link, useParams } from 'react-router-dom'
-import { getAppRoute } from 'utils/getAppRoute'
+import { APP_ROUTES } from 'utils/constants'
 import { STRING, translate } from 'utils/language'
 
 export const DeploymentsMapPopupContent = ({
@@ -14,10 +14,9 @@ export const DeploymentsMapPopupContent = ({
     <>
       <p>
         <Link
-          to={getAppRoute({
+          to={APP_ROUTES.DEPLOYMENT_DETAILS({
             projectId: projectId as string,
-            collection: 'deployments',
-            itemId: deployment.id,
+            deploymentId: deployment.id,
           })}
         >
           <span>{deployment.name}</span>

--- a/ui/src/pages/projects/project-gallery.tsx
+++ b/ui/src/pages/projects/project-gallery.tsx
@@ -2,7 +2,7 @@ import { Gallery } from 'components/gallery/gallery'
 import { Project } from 'data-services/models/project'
 import { CardSize } from 'design-system/components/card/card'
 import { useMemo } from 'react'
-import { getRoute } from 'utils/getRoute'
+import { getAppRoute } from 'utils/getAppRoute'
 
 export const ProjectGallery = ({
   projects = [],
@@ -22,7 +22,7 @@ export const ProjectGallery = ({
           : undefined,
         title: p.name,
         subTitle: p.description,
-        to: getRoute({
+        to: getAppRoute({
           projectId: p.id,
         }),
       })),

--- a/ui/src/pages/projects/project-gallery.tsx
+++ b/ui/src/pages/projects/project-gallery.tsx
@@ -2,7 +2,7 @@ import { Gallery } from 'components/gallery/gallery'
 import { Project } from 'data-services/models/project'
 import { CardSize } from 'design-system/components/card/card'
 import { useMemo } from 'react'
-import { getAppRoute } from 'utils/getAppRoute'
+import { APP_ROUTES } from 'utils/constants'
 
 export const ProjectGallery = ({
   projects = [],
@@ -22,9 +22,7 @@ export const ProjectGallery = ({
           : undefined,
         title: p.name,
         subTitle: p.description,
-        to: getAppRoute({
-          projectId: p.id,
-        }),
+        to: APP_ROUTES.PROJECT_DETAILS({ projectId: p.id }),
       })),
     [projects]
   )

--- a/ui/src/pages/session-details/playback/frame/frame.tsx
+++ b/ui/src/pages/session-details/playback/frame/frame.tsx
@@ -4,7 +4,7 @@ import { LoadingSpinner } from 'design-system/components/loading-spinner/loading
 import { Tooltip } from 'design-system/components/tooltip/tooltip'
 import { useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { useParams } from 'react-router-dom'
-import { getAppRoute } from 'utils/getAppRoute'
+import { APP_ROUTES } from 'utils/constants'
 import { useActiveOccurrences } from '../useActiveOccurrences'
 import styles from './frame.module.scss'
 import { BoxStyle } from './types'
@@ -160,10 +160,9 @@ const FrameDetections = ({
             content={detection?.label ?? ''}
             frame={containerRef.current}
             open={isActive ? isActive : undefined}
-            to={getAppRoute({
+            to={APP_ROUTES.OCCURRENCE_DETAILS({
               projectId: projectId as string,
-              collection: 'occurrences',
-              itemId: detection.occurrenceId,
+              occurrenceId: detection.occurrenceId,
             })}
           >
             <div

--- a/ui/src/pages/session-details/playback/frame/frame.tsx
+++ b/ui/src/pages/session-details/playback/frame/frame.tsx
@@ -4,7 +4,7 @@ import { LoadingSpinner } from 'design-system/components/loading-spinner/loading
 import { Tooltip } from 'design-system/components/tooltip/tooltip'
 import { useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { useParams } from 'react-router-dom'
-import { getRoute } from 'utils/getRoute'
+import { getAppRoute } from 'utils/getAppRoute'
 import { useActiveOccurrences } from '../useActiveOccurrences'
 import styles from './frame.module.scss'
 import { BoxStyle } from './types'
@@ -160,7 +160,7 @@ const FrameDetections = ({
             content={detection?.label ?? ''}
             frame={containerRef.current}
             open={isActive ? isActive : undefined}
-            to={getRoute({
+            to={getAppRoute({
               projectId: projectId as string,
               collection: 'occurrences',
               itemId: detection.occurrenceId,

--- a/ui/src/pages/session-details/session-details.tsx
+++ b/ui/src/pages/session-details/session-details.tsx
@@ -6,7 +6,7 @@ import { Error } from 'pages/error/error'
 import { useContext, useEffect } from 'react'
 import { useParams } from 'react-router-dom'
 import { BreadcrumbContext } from 'utils/breadcrumbContext'
-import { getRoute } from 'utils/getRoute'
+import { getAppRoute } from 'utils/getAppRoute'
 import { Playback } from './playback/playback'
 import { useActiveCaptureId } from './playback/useActiveCapture'
 import { useActiveOccurrences } from './playback/useActiveOccurrences'
@@ -26,7 +26,7 @@ export const SessionDetails = () => {
   useEffect(() => {
     setDetailBreadcrumb({
       title: session?.label ?? '',
-      path: getRoute({
+      path: getAppRoute({
         projectId: projectId as string,
         collection: 'sessions',
         itemId: id,

--- a/ui/src/pages/session-details/session-details.tsx
+++ b/ui/src/pages/session-details/session-details.tsx
@@ -6,7 +6,7 @@ import { Error } from 'pages/error/error'
 import { useContext, useEffect } from 'react'
 import { useParams } from 'react-router-dom'
 import { BreadcrumbContext } from 'utils/breadcrumbContext'
-import { getAppRoute } from 'utils/getAppRoute'
+import { APP_ROUTES } from 'utils/constants'
 import { Playback } from './playback/playback'
 import { useActiveCaptureId } from './playback/useActiveCapture'
 import { useActiveOccurrences } from './playback/useActiveOccurrences'
@@ -26,10 +26,9 @@ export const SessionDetails = () => {
   useEffect(() => {
     setDetailBreadcrumb({
       title: session?.label ?? '',
-      path: getAppRoute({
+      path: APP_ROUTES.SESSION_DETAILS({
         projectId: projectId as string,
-        collection: 'sessions',
-        itemId: id,
+        sessionId: id as string,
       }),
     })
 

--- a/ui/src/pages/session-details/session-info/session-info.tsx
+++ b/ui/src/pages/session-details/session-info/session-info.tsx
@@ -1,7 +1,7 @@
 import { Session } from 'data-services/models/session'
 import { InfoBlock } from 'design-system/components/info-block/info-block'
 import { useParams } from 'react-router-dom'
-import { getRoute } from 'utils/getRoute'
+import { getAppRoute } from 'utils/getAppRoute'
 import { STRING, translate } from 'utils/language'
 import styles from './session-info.module.scss'
 
@@ -12,7 +12,7 @@ export const SessionInfo = ({ session }: { session: Session }) => {
     {
       label: translate(STRING.FIELD_LABEL_DEPLOYMENT),
       value: session.deploymentLabel,
-      to: getRoute({
+      to: getAppRoute({
         projectId: projectId as string,
         collection: 'deployments',
         itemId: session.deploymentId,
@@ -41,7 +41,7 @@ export const SessionInfo = ({ session }: { session: Session }) => {
     {
       label: translate(STRING.FIELD_LABEL_OCCURRENCES),
       value: session.numOccurrences,
-      to: getRoute({
+      to: getAppRoute({
         projectId: projectId as string,
         collection: 'occurrences',
         filters: { event: session.id },
@@ -50,7 +50,7 @@ export const SessionInfo = ({ session }: { session: Session }) => {
     {
       label: translate(STRING.FIELD_LABEL_SPECIES),
       value: session.numSpecies,
-      to: getRoute({
+      to: getAppRoute({
         projectId: projectId as string,
         collection: 'species',
         filters: { occurrences__event: session.id },

--- a/ui/src/pages/session-details/session-info/session-info.tsx
+++ b/ui/src/pages/session-details/session-info/session-info.tsx
@@ -1,6 +1,7 @@
 import { Session } from 'data-services/models/session'
 import { InfoBlock } from 'design-system/components/info-block/info-block'
 import { useParams } from 'react-router-dom'
+import { APP_ROUTES } from 'utils/constants'
 import { getAppRoute } from 'utils/getAppRoute'
 import { STRING, translate } from 'utils/language'
 import styles from './session-info.module.scss'
@@ -12,10 +13,9 @@ export const SessionInfo = ({ session }: { session: Session }) => {
     {
       label: translate(STRING.FIELD_LABEL_DEPLOYMENT),
       value: session.deploymentLabel,
-      to: getAppRoute({
+      to: APP_ROUTES.DEPLOYMENT_DETAILS({
         projectId: projectId as string,
-        collection: 'deployments',
-        itemId: session.deploymentId,
+        deploymentId: session.deploymentId,
       }),
     },
     {
@@ -42,8 +42,7 @@ export const SessionInfo = ({ session }: { session: Session }) => {
       label: translate(STRING.FIELD_LABEL_OCCURRENCES),
       value: session.numOccurrences,
       to: getAppRoute({
-        projectId: projectId as string,
-        collection: 'occurrences',
+        to: APP_ROUTES.OCCURRENCES({ projectId: projectId as string }),
         filters: { event: session.id },
       }),
     },
@@ -51,8 +50,7 @@ export const SessionInfo = ({ session }: { session: Session }) => {
       label: translate(STRING.FIELD_LABEL_SPECIES),
       value: session.numSpecies,
       to: getAppRoute({
-        projectId: projectId as string,
-        collection: 'species',
+        to: APP_ROUTES.SPECIES({ projectId: projectId as string }),
         filters: { occurrences__event: session.id },
       }),
     },

--- a/ui/src/pages/sessions/session-columns.tsx
+++ b/ui/src/pages/sessions/session-columns.tsx
@@ -8,6 +8,7 @@ import {
   TextAlign,
 } from 'design-system/components/table/types'
 import { Link } from 'react-router-dom'
+import { APP_ROUTES } from 'utils/constants'
 import { getAppRoute } from 'utils/getAppRoute'
 import { STRING, translate } from 'utils/language'
 
@@ -35,9 +36,7 @@ export const columns: (projectId: string) => TableColumn<Session>[] = (
     id: 'session',
     name: translate(STRING.FIELD_LABEL_SESSION),
     renderCell: (item: Session) => (
-      <Link
-        to={getAppRoute({ projectId, collection: 'sessions', itemId: item.id })}
-      >
+      <Link to={APP_ROUTES.SESSION_DETAILS({ projectId, sessionId: item.id })}>
         <BasicTableCell value={item.label} theme={CellTheme.Primary} />
       </Link>
     ),
@@ -47,10 +46,9 @@ export const columns: (projectId: string) => TableColumn<Session>[] = (
     name: translate(STRING.FIELD_LABEL_DEPLOYMENT),
     renderCell: (item: Session) => (
       <Link
-        to={getAppRoute({
+        to={APP_ROUTES.DEPLOYMENT_DETAILS({
           projectId,
-          collection: 'deployments',
-          itemId: item.deploymentId,
+          deploymentId: item.deploymentId,
         })}
       >
         <BasicTableCell
@@ -112,8 +110,7 @@ export const columns: (projectId: string) => TableColumn<Session>[] = (
     renderCell: (item: Session) => (
       <Link
         to={getAppRoute({
-          projectId,
-          collection: 'occurrences',
+          to: APP_ROUTES.OCCURRENCES({ projectId }),
           filters: { event: item.id },
         })}
       >
@@ -130,8 +127,7 @@ export const columns: (projectId: string) => TableColumn<Session>[] = (
     renderCell: (item: Session) => (
       <Link
         to={getAppRoute({
-          projectId,
-          collection: 'species',
+          to: APP_ROUTES.SPECIES({ projectId }),
           filters: { occurrences__event: item.id },
         })}
       >

--- a/ui/src/pages/sessions/session-columns.tsx
+++ b/ui/src/pages/sessions/session-columns.tsx
@@ -8,7 +8,7 @@ import {
   TextAlign,
 } from 'design-system/components/table/types'
 import { Link } from 'react-router-dom'
-import { getRoute } from 'utils/getRoute'
+import { getAppRoute } from 'utils/getAppRoute'
 import { STRING, translate } from 'utils/language'
 
 export const columns: (projectId: string) => TableColumn<Session>[] = (
@@ -36,7 +36,7 @@ export const columns: (projectId: string) => TableColumn<Session>[] = (
     name: translate(STRING.FIELD_LABEL_SESSION),
     renderCell: (item: Session) => (
       <Link
-        to={getRoute({ projectId, collection: 'sessions', itemId: item.id })}
+        to={getAppRoute({ projectId, collection: 'sessions', itemId: item.id })}
       >
         <BasicTableCell value={item.label} theme={CellTheme.Primary} />
       </Link>
@@ -47,7 +47,7 @@ export const columns: (projectId: string) => TableColumn<Session>[] = (
     name: translate(STRING.FIELD_LABEL_DEPLOYMENT),
     renderCell: (item: Session) => (
       <Link
-        to={getRoute({
+        to={getAppRoute({
           projectId,
           collection: 'deployments',
           itemId: item.deploymentId,
@@ -111,7 +111,7 @@ export const columns: (projectId: string) => TableColumn<Session>[] = (
     },
     renderCell: (item: Session) => (
       <Link
-        to={getRoute({
+        to={getAppRoute({
           projectId,
           collection: 'occurrences',
           filters: { event: item.id },
@@ -129,7 +129,7 @@ export const columns: (projectId: string) => TableColumn<Session>[] = (
     },
     renderCell: (item: Session) => (
       <Link
-        to={getRoute({
+        to={getAppRoute({
           projectId,
           collection: 'species',
           filters: { occurrences__event: item.id },

--- a/ui/src/pages/sessions/session-gallery.tsx
+++ b/ui/src/pages/sessions/session-gallery.tsx
@@ -2,7 +2,7 @@ import { Gallery } from 'components/gallery/gallery'
 import { Session } from 'data-services/models/session'
 import { useMemo } from 'react'
 import { useParams } from 'react-router-dom'
-import { getAppRoute } from 'utils/getAppRoute'
+import { APP_ROUTES } from 'utils/constants'
 
 export const SessionGallery = ({
   sessions = [],
@@ -19,10 +19,9 @@ export const SessionGallery = ({
         id: s.id,
         image: s.exampleCaptures?.[0],
         title: s.label,
-        to: getAppRoute({
+        to: APP_ROUTES.SESSION_DETAILS({
           projectId: projectId as string,
-          collection: 'sessions',
-          itemId: s.id,
+          sessionId: s.id,
         }),
       })),
     [sessions, projectId]

--- a/ui/src/pages/sessions/session-gallery.tsx
+++ b/ui/src/pages/sessions/session-gallery.tsx
@@ -2,7 +2,7 @@ import { Gallery } from 'components/gallery/gallery'
 import { Session } from 'data-services/models/session'
 import { useMemo } from 'react'
 import { useParams } from 'react-router-dom'
-import { getRoute } from 'utils/getRoute'
+import { getAppRoute } from 'utils/getAppRoute'
 
 export const SessionGallery = ({
   sessions = [],
@@ -19,7 +19,7 @@ export const SessionGallery = ({
         id: s.id,
         image: s.exampleCaptures?.[0],
         title: s.label,
-        to: getRoute({
+        to: getAppRoute({
           projectId: projectId as string,
           collection: 'sessions',
           itemId: s.id,

--- a/ui/src/pages/species-details/species-details.tsx
+++ b/ui/src/pages/species-details/species-details.tsx
@@ -6,6 +6,7 @@ import { SpeciesDetails as Species } from 'data-services/models/species-details'
 import { InfoBlock } from 'design-system/components/info-block/info-block'
 import { useMemo } from 'react'
 import { useParams } from 'react-router-dom'
+import { APP_ROUTES } from 'utils/constants'
 import { getAppRoute } from 'utils/getAppRoute'
 import { STRING, translate } from 'utils/language'
 import styles from './species-details.module.scss'
@@ -21,10 +22,9 @@ export const SpeciesDetails = ({ species }: { species: Species }) => {
             .filter((item): item is BlueprintItem => !!item)
             .map((item) => ({
               ...item,
-              to: getAppRoute({
+              to: APP_ROUTES.OCCURRENCE_DETAILS({
                 projectId: projectId as string,
-                collection: 'occurrences',
-                itemId: item.id,
+                occurrenceId: item.id,
               }),
             }))
         : [],
@@ -40,8 +40,7 @@ export const SpeciesDetails = ({ species }: { species: Species }) => {
       label: translate(STRING.FIELD_LABEL_OCCURRENCES),
       value: species.numOccurrences,
       to: getAppRoute({
-        projectId: projectId as string,
-        collection: 'occurrences',
+        to: APP_ROUTES.OCCURRENCES({ projectId: projectId as string }),
         filters: { determination: species.id },
       }),
     },

--- a/ui/src/pages/species-details/species-details.tsx
+++ b/ui/src/pages/species-details/species-details.tsx
@@ -6,7 +6,7 @@ import { SpeciesDetails as Species } from 'data-services/models/species-details'
 import { InfoBlock } from 'design-system/components/info-block/info-block'
 import { useMemo } from 'react'
 import { useParams } from 'react-router-dom'
-import { getRoute } from 'utils/getRoute'
+import { getAppRoute } from 'utils/getAppRoute'
 import { STRING, translate } from 'utils/language'
 import styles from './species-details.module.scss'
 
@@ -21,7 +21,7 @@ export const SpeciesDetails = ({ species }: { species: Species }) => {
             .filter((item): item is BlueprintItem => !!item)
             .map((item) => ({
               ...item,
-              to: getRoute({
+              to: getAppRoute({
                 projectId: projectId as string,
                 collection: 'occurrences',
                 itemId: item.id,
@@ -39,7 +39,7 @@ export const SpeciesDetails = ({ species }: { species: Species }) => {
     {
       label: translate(STRING.FIELD_LABEL_OCCURRENCES),
       value: species.numOccurrences,
-      to: getRoute({
+      to: getAppRoute({
         projectId: projectId as string,
         collection: 'occurrences',
         filters: { determination: species.id },

--- a/ui/src/pages/species/species-columns.tsx
+++ b/ui/src/pages/species/species-columns.tsx
@@ -8,7 +8,7 @@ import {
   TextAlign,
 } from 'design-system/components/table/types'
 import { Link } from 'react-router-dom'
-import { getRoute } from 'utils/getRoute'
+import { getAppRoute } from 'utils/getAppRoute'
 import { STRING, translate } from 'utils/language'
 
 export const columns: (projectId: string) => TableColumn<Species>[] = (
@@ -38,7 +38,7 @@ export const columns: (projectId: string) => TableColumn<Species>[] = (
     name: translate(STRING.FIELD_LABEL_NAME),
     renderCell: (item: Species) => (
       <Link
-        to={getRoute({
+        to={getAppRoute({
           projectId,
           collection: 'species',
           itemId: item.id,
@@ -67,7 +67,7 @@ export const columns: (projectId: string) => TableColumn<Species>[] = (
     },
     renderCell: (item: Species) => (
       <Link
-        to={getRoute({
+        to={getAppRoute({
           projectId,
           collection: 'occurrences',
           filters: { determination: item.id },

--- a/ui/src/pages/species/species-columns.tsx
+++ b/ui/src/pages/species/species-columns.tsx
@@ -8,6 +8,7 @@ import {
   TextAlign,
 } from 'design-system/components/table/types'
 import { Link } from 'react-router-dom'
+import { APP_ROUTES } from 'utils/constants'
 import { getAppRoute } from 'utils/getAppRoute'
 import { STRING, translate } from 'utils/language'
 
@@ -39,9 +40,7 @@ export const columns: (projectId: string) => TableColumn<Species>[] = (
     renderCell: (item: Species) => (
       <Link
         to={getAppRoute({
-          projectId,
-          collection: 'species',
-          itemId: item.id,
+          to: APP_ROUTES.SPECIES_DETAILS({ projectId, speciesId: item.id }),
           keepSearchParams: true,
         })}
       >
@@ -68,8 +67,7 @@ export const columns: (projectId: string) => TableColumn<Species>[] = (
     renderCell: (item: Species) => (
       <Link
         to={getAppRoute({
-          projectId,
-          collection: 'occurrences',
+          to: APP_ROUTES.OCCURRENCES({ projectId }),
           filters: { determination: item.id },
         })}
       >

--- a/ui/src/pages/species/species-gallery.tsx
+++ b/ui/src/pages/species/species-gallery.tsx
@@ -2,6 +2,7 @@ import { Gallery } from 'components/gallery/gallery'
 import { Species } from 'data-services/models/species'
 import { useMemo } from 'react'
 import { useParams } from 'react-router-dom'
+import { APP_ROUTES } from 'utils/constants'
 import { getAppRoute } from 'utils/getAppRoute'
 
 export const SpeciesGallery = ({
@@ -20,9 +21,10 @@ export const SpeciesGallery = ({
         image: s.images[0],
         title: s.name,
         to: getAppRoute({
-          projectId: projectId as string,
-          collection: 'species',
-          itemId: s.id,
+          to: APP_ROUTES.SPECIES_DETAILS({
+            projectId: projectId as string,
+            speciesId: s.id,
+          }),
           keepSearchParams: true,
         }),
       })),

--- a/ui/src/pages/species/species-gallery.tsx
+++ b/ui/src/pages/species/species-gallery.tsx
@@ -2,7 +2,7 @@ import { Gallery } from 'components/gallery/gallery'
 import { Species } from 'data-services/models/species'
 import { useMemo } from 'react'
 import { useParams } from 'react-router-dom'
-import { getRoute } from 'utils/getRoute'
+import { getAppRoute } from 'utils/getAppRoute'
 
 export const SpeciesGallery = ({
   species = [],
@@ -19,7 +19,7 @@ export const SpeciesGallery = ({
         id: s.id,
         image: s.images[0],
         title: s.name,
-        to: getRoute({
+        to: getAppRoute({
           projectId: projectId as string,
           collection: 'species',
           itemId: s.id,

--- a/ui/src/pages/species/species.tsx
+++ b/ui/src/pages/species/species.tsx
@@ -12,7 +12,7 @@ import { Error } from 'pages/error/error'
 import { SpeciesDetails } from 'pages/species-details/species-details'
 import { useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
-import { getRoute } from 'utils/getRoute'
+import { getAppRoute } from 'utils/getAppRoute'
 import { STRING, translate } from 'utils/language'
 import { useFilters } from 'utils/useFilters'
 import { usePagination } from 'utils/usePagination'
@@ -98,7 +98,7 @@ const SpeciesDetailsDialog = ({ id }: { id: string }) => {
       open={!!id}
       onOpenChange={() =>
         navigate(
-          getRoute({
+          getAppRoute({
             projectId: projectId as string,
             collection: 'species',
             keepSearchParams: true,

--- a/ui/src/pages/species/species.tsx
+++ b/ui/src/pages/species/species.tsx
@@ -12,6 +12,7 @@ import { Error } from 'pages/error/error'
 import { SpeciesDetails } from 'pages/species-details/species-details'
 import { useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
+import { APP_ROUTES } from 'utils/constants'
 import { getAppRoute } from 'utils/getAppRoute'
 import { STRING, translate } from 'utils/language'
 import { useFilters } from 'utils/useFilters'
@@ -99,8 +100,7 @@ const SpeciesDetailsDialog = ({ id }: { id: string }) => {
       onOpenChange={() =>
         navigate(
           getAppRoute({
-            projectId: projectId as string,
-            collection: 'species',
+            to: APP_ROUTES.SPECIES({ projectId: projectId as string }),
             keepSearchParams: true,
           })
         )

--- a/ui/src/utils/constants.ts
+++ b/ui/src/utils/constants.ts
@@ -1,6 +1,40 @@
 export const APP_ROUTES = {
+  /* Static app routes */
   HOME: '/',
   LOGIN: '/auth/login',
   SIGN_UP: '/auth/sign-up',
   PROJECTS: '/projects',
+
+  /* Dynamic app routes */
+  PROJECT_DETAILS: (params: { projectId: string }) =>
+    `/projects/${params.projectId}`,
+
+  DEPLOYMENTS: (params: { projectId: string }) =>
+    `/projects/${params.projectId}/deployments`,
+
+  DEPLOYMENT_DETAILS: (params: { projectId: string; deploymentId: string }) =>
+    `/projects/${params.projectId}/deployments/${params.deploymentId}`,
+
+  JOBS: (params: { projectId: string }) => `/projects/${params.projectId}/jobs`,
+
+  JOB_DETAILS: (params: { projectId: string; jobId: string }) =>
+    `/projects/${params.projectId}/jobs/${params.jobId}`,
+
+  SESSIONS: (params: { projectId: string }) =>
+    `/projects/${params.projectId}/sessions`,
+
+  SESSION_DETAILS: (params: { projectId: string; sessionId: string }) =>
+    `/projects/${params.projectId}/sessions/${params.sessionId}`,
+
+  OCCURRENCES: (params: { projectId: string }) =>
+    `/projects/${params.projectId}/occurrences`,
+
+  OCCURRENCE_DETAILS: (params: { projectId: string; occurrenceId: string }) =>
+    `/projects/${params.projectId}/occurrences/${params.occurrenceId}`,
+
+  SPECIES: (params: { projectId: string }) =>
+    `/projects/${params.projectId}/species`,
+
+  SPECIES_DETAILS: (params: { projectId: string; speciesId: string }) =>
+    `/projects/${params.projectId}/species/${params.speciesId}`,
 }

--- a/ui/src/utils/constants.ts
+++ b/ui/src/utils/constants.ts
@@ -1,5 +1,6 @@
-export const LINKS = {
+export const APP_ROUTES = {
   HOME: '/',
   LOGIN: '/auth/login',
   SIGN_UP: '/auth/sign-up',
+  PROJECTS: '/projects',
 }

--- a/ui/src/utils/getAppRoute.ts
+++ b/ui/src/utils/getAppRoute.ts
@@ -1,3 +1,5 @@
+import { APP_ROUTES } from './constants'
+
 type CollectionType =
   | 'jobs'
   | 'deployments'
@@ -14,7 +16,7 @@ type FilterType =
   | 'occurrence'
   | 'capture'
 
-export const getRoute = ({
+export const getAppRoute = ({
   projectId,
   collection,
   itemId,
@@ -27,7 +29,7 @@ export const getRoute = ({
   filters?: Partial<Record<FilterType, string | undefined>>
   keepSearchParams?: boolean
 }) => {
-  let url = `/projects/${projectId}`
+  let url = `${APP_ROUTES.PROJECTS}/${projectId}`
 
   if (collection) {
     url = `${url}/${collection}`

--- a/ui/src/utils/getAppRoute.ts
+++ b/ui/src/utils/getAppRoute.ts
@@ -1,12 +1,3 @@
-import { APP_ROUTES } from './constants'
-
-type CollectionType =
-  | 'jobs'
-  | 'deployments'
-  | 'sessions'
-  | 'occurrences'
-  | 'species'
-
 type FilterType =
   | 'deployment'
   | 'event'
@@ -17,27 +8,15 @@ type FilterType =
   | 'capture'
 
 export const getAppRoute = ({
-  projectId,
-  collection,
-  itemId,
+  to,
   filters = {},
   keepSearchParams,
 }: {
-  projectId: string
-  collection?: CollectionType
-  itemId?: string
+  to: string
   filters?: Partial<Record<FilterType, string | undefined>>
   keepSearchParams?: boolean
 }) => {
-  let url = `${APP_ROUTES.PROJECTS}/${projectId}`
-
-  if (collection) {
-    url = `${url}/${collection}`
-
-    if (itemId?.length) {
-      url = `${url}/${itemId}`
-    }
-  }
+  let url = `${to}`
 
   const searchParams = new URLSearchParams(
     keepSearchParams ? window.location.search : undefined
@@ -47,10 +26,8 @@ export const getAppRoute = ({
       searchParams.set(name, value)
     }
   })
-
-  const queryString = searchParams.toString()
-  if (queryString.length) {
-    url = `${url}?${queryString}`
+  if (searchParams.toString().length) {
+    url = `${url}?${searchParams}`
   }
 
   return url

--- a/ui/src/utils/useNavItems.ts
+++ b/ui/src/utils/useNavItems.ts
@@ -2,7 +2,7 @@ import { useStatus } from 'data-services/hooks/useStatus'
 import { IconType } from 'design-system/components/icon/icon'
 import { useMemo } from 'react'
 import { matchPath, useLocation, useParams } from 'react-router-dom'
-import { getRoute } from './getRoute'
+import { getAppRoute } from './getAppRoute'
 import { STRING, translate } from './language'
 
 interface NavigationItem {
@@ -25,7 +25,7 @@ export const useNavItems = () => {
         id: 'overview',
         title: translate(STRING.NAV_ITEM_OVERVIEW),
         icon: IconType.Overview,
-        path: getRoute({
+        path: getAppRoute({
           projectId: projectId as string,
           collection: undefined,
         }),
@@ -35,7 +35,10 @@ export const useNavItems = () => {
         id: 'jobs',
         title: translate(STRING.NAV_ITEM_JOBS),
         icon: IconType.BatchId,
-        path: getRoute({ projectId: projectId as string, collection: 'jobs' }),
+        path: getAppRoute({
+          projectId: projectId as string,
+          collection: 'jobs',
+        }),
         matchPath: '/projects/:projectId/jobs/*',
       },
       {
@@ -43,7 +46,7 @@ export const useNavItems = () => {
         title: translate(STRING.NAV_ITEM_DEPLOYMENTS),
         icon: IconType.Deployments,
         count: status?.numDeployments,
-        path: getRoute({
+        path: getAppRoute({
           projectId: projectId as string,
           collection: 'deployments',
         }),
@@ -54,7 +57,7 @@ export const useNavItems = () => {
         title: translate(STRING.NAV_ITEM_SESSIONS),
         icon: IconType.Sessions,
         count: status?.numSessions,
-        path: getRoute({
+        path: getAppRoute({
           projectId: projectId as string,
           collection: 'sessions',
         }),
@@ -65,7 +68,7 @@ export const useNavItems = () => {
         title: translate(STRING.NAV_ITEM_OCCURRENCES),
         icon: IconType.Occurrences,
         count: status?.numOccurrences,
-        path: getRoute({
+        path: getAppRoute({
           projectId: projectId as string,
           collection: 'occurrences',
         }),
@@ -76,7 +79,7 @@ export const useNavItems = () => {
         title: translate(STRING.NAV_ITEM_SPECIES),
         icon: IconType.Species,
         count: status?.numSpecies,
-        path: getRoute({
+        path: getAppRoute({
           projectId: projectId as string,
           collection: 'species',
         }),

--- a/ui/src/utils/useNavItems.ts
+++ b/ui/src/utils/useNavItems.ts
@@ -2,7 +2,7 @@ import { useStatus } from 'data-services/hooks/useStatus'
 import { IconType } from 'design-system/components/icon/icon'
 import { useMemo } from 'react'
 import { matchPath, useLocation, useParams } from 'react-router-dom'
-import { getAppRoute } from './getAppRoute'
+import { APP_ROUTES } from './constants'
 import { STRING, translate } from './language'
 
 interface NavigationItem {
@@ -25,65 +25,62 @@ export const useNavItems = () => {
         id: 'overview',
         title: translate(STRING.NAV_ITEM_OVERVIEW),
         icon: IconType.Overview,
-        path: getAppRoute({
-          projectId: projectId as string,
-          collection: undefined,
-        }),
-        matchPath: '/projects/:projectId',
+        path: APP_ROUTES.PROJECT_DETAILS({ projectId: projectId as string }),
+        matchPath: APP_ROUTES.PROJECT_DETAILS({ projectId: ':projectId' }),
       },
       {
         id: 'jobs',
         title: translate(STRING.NAV_ITEM_JOBS),
         icon: IconType.BatchId,
-        path: getAppRoute({
-          projectId: projectId as string,
-          collection: 'jobs',
+        path: APP_ROUTES.JOBS({ projectId: projectId as string }),
+        matchPath: APP_ROUTES.JOB_DETAILS({
+          projectId: ':projectId',
+          jobId: '*',
         }),
-        matchPath: '/projects/:projectId/jobs/*',
       },
       {
         id: 'deployments',
         title: translate(STRING.NAV_ITEM_DEPLOYMENTS),
         icon: IconType.Deployments,
         count: status?.numDeployments,
-        path: getAppRoute({
-          projectId: projectId as string,
-          collection: 'deployments',
+        path: APP_ROUTES.DEPLOYMENTS({ projectId: projectId as string }),
+        matchPath: APP_ROUTES.DEPLOYMENT_DETAILS({
+          projectId: ':projectId',
+          deploymentId: '*',
         }),
-        matchPath: '/projects/:projectId/deployments/*',
       },
       {
         id: 'sessions',
         title: translate(STRING.NAV_ITEM_SESSIONS),
         icon: IconType.Sessions,
         count: status?.numSessions,
-        path: getAppRoute({
-          projectId: projectId as string,
-          collection: 'sessions',
+        path: APP_ROUTES.SESSIONS({ projectId: projectId as string }),
+        matchPath: APP_ROUTES.SESSION_DETAILS({
+          projectId: ':projectId',
+          sessionId: '*',
         }),
-        matchPath: '/projects/:projectId/sessions/*',
       },
       {
         id: 'occurrences',
         title: translate(STRING.NAV_ITEM_OCCURRENCES),
         icon: IconType.Occurrences,
         count: status?.numOccurrences,
-        path: getAppRoute({
-          projectId: projectId as string,
-          collection: 'occurrences',
+        path: APP_ROUTES.OCCURRENCES({ projectId: projectId as string }),
+        matchPath: APP_ROUTES.OCCURRENCE_DETAILS({
+          projectId: ':projectId',
+          occurrenceId: '*',
         }),
-        matchPath: '/projects/:projectId/occurrences/*',
       },
       {
         id: 'species',
         title: translate(STRING.NAV_ITEM_SPECIES),
         icon: IconType.Species,
         count: status?.numSpecies,
-        path: getAppRoute({
-          projectId: projectId as string,
-          collection: 'species',
+        path: APP_ROUTES.SPECIES({ projectId: projectId as string }),
+        matchPath: APP_ROUTES.SPECIES_DETAILS({
+          projectId: ':projectId',
+          speciesId: '*',
         }),
-        matchPath: '/projects/:projectId/species/*',
       },
     ],
     [status, projectId]


### PR DESCRIPTION
I realise I have been a bit inconsistent with the naming in code around routes. From now on, I will try to use **app routes** for the front end routing (instead of just "routes" or "links"). For the BE routes, I will keep call them **API routes** in code.

Summary of changes:
- Rename LINKS -> APP_ROUTES
- Rename getRoute -> getAppRoute
- Included all dynamic app routes in APP_ROUTES, which made it possible to simplify getAppRoute. The previous version of getAppRoute was perhaps a bit too generic, I thought code got a bit more explicit in this way. What do you think?
- Replaced some hard coded values in hook useNavItems

I feel it would be nice if we could get rid of `getAppRoute` completely, but I haven't come up with a good way to do this yet without introducing a lot of repetition for the query params...