### PR TITLE
Updates to build triggers

### DIFF
--- a/.github/workflows/test.backend.yml
+++ b/.github/workflows/test.backend.yml
@@ -31,7 +31,7 @@ jobs:
           python-version: "3.11"
       # Consider using pre-commit.ci for open source project
       - name: Run pre-commit
-        uses: pre-commit/action@v3.0.0
+        uses: pre-commit-ci/action
 
   # With no caching at all the entire ci process takes 4m 30s to complete!
   test:

--- a/.github/workflows/test.backend.yml
+++ b/.github/workflows/test.backend.yml
@@ -31,7 +31,7 @@ jobs:
           python-version: "3.11"
       # Consider using pre-commit.ci for open source project
       - name: Run pre-commit
-        uses: pre-commit-ci/action
+        uses: pre-commit/action@v3.0.0
 
   # With no caching at all the entire ci process takes 4m 30s to complete!
   test:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,13 +50,6 @@ repos:
       - id: djlint-reformat-django
       - id: djlint-django
 
-  - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: v8.49.0
-    hooks:
-      - id: eslint
-        files: \.[jt]sx?$ # *.js, *.jsx, *.ts and *.tsx
-        types: [file]
-
 # sets up .pre-commit-ci.yaml to ensure pre-commit dependencies stay up to date
 ci:
   autoupdate_schedule: weekly

--- a/ami/main/models.py
+++ b/ami/main/models.py
@@ -1568,3 +1568,6 @@ class Page(BaseModel):
             return markdown(self.content, extensions=[])
         else:
             return ""
+
+
+# test change for pre-commit

--- a/ui/netlify.toml
+++ b/ui/netlify.toml
@@ -43,3 +43,7 @@ from = "/*"
 to = "/"
 status = 200
 force = false
+
+[build]
+# Only trigger a build if the frontend code has changed
+ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF ui"


### PR DESCRIPTION
- Remove eslint from pre-commit. Was running and failing for all backend builds due to missing typescript plugin. The frontend actions run eslint directly.
- Disable netlify builds for non-UI changes to save build minutes.