### PR TITLE
Tweak profile image UI

### DIFF
--- a/ui/src/components/header/user-info-dialog/user-info-image-upload/user-info-image-upload.module.scss
+++ b/ui/src/components/header/user-info-dialog/user-info-image-upload/user-info-image-upload.module.scss
@@ -17,14 +17,14 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 16px;
+  gap: 8px;
   @include paragraph-small();
   color: $color-neutral-500;
 
   img {
-    max-width: 100%;
-    max-height: 100%;
-    object-fit: contain;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
   }
 }
 
@@ -32,19 +32,5 @@
   position: absolute;
   width: 100%;
   height: 100%;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  background-color: rgba($color: $color-primary-2-50, $alpha: 0.7);
-
-  &.hasImage {
-    opacity: 0;
-    transition: opacity 200ms ease-in-out;
-
-    &:hover,
-    &:focus-within {
-      opacity: 1;
-    }
-  }
+  vertical-align: middle;
 }

--- a/ui/src/components/header/user-info-dialog/user-info-image-upload/user-info-image-upload.tsx
+++ b/ui/src/components/header/user-info-dialog/user-info-image-upload/user-info-image-upload.tsx
@@ -1,6 +1,5 @@
 import { FileInput } from 'design-system/components/file-input/file-input'
 import { FileInputAccept } from 'design-system/components/file-input/types'
-import { useState } from 'react'
 import { UserInfo } from 'utils/user/types'
 import styles from './user-info-image-upload.module.scss'
 
@@ -13,7 +12,6 @@ export const UserInfoImageUpload = ({
   userInfo: UserInfo
   onChange: (file: File | null) => void
 }) => {
-  const [_size, setSize] = useState<{ width: number; height: number }>()
   const imageUrl = (() => {
     if (file) {
       return URL.createObjectURL(file)
@@ -30,14 +28,7 @@ export const UserInfoImageUpload = ({
         <div className={styles.content}>
           {imageUrl ? (
             <>
-              <img
-                src={imageUrl}
-                onLoad={(e) => {
-                  const width = e.currentTarget.naturalWidth
-                  const height = e.currentTarget.naturalHeight
-                  setSize({ width, height })
-                }}
-              />
+              <img src={imageUrl} />
               <ImageOverlay />
             </>
           ) : (
@@ -47,7 +38,7 @@ export const UserInfoImageUpload = ({
       </div>
       <FileInput
         accept={FileInputAccept.Images}
-        label="Choose image"
+        label={imageUrl ? 'Change image' : 'Choose image'}
         name="user-image"
         onChange={onChange}
       />

--- a/ui/src/components/header/user-info-dialog/user-info-image-upload/user-info-image-upload.tsx
+++ b/ui/src/components/header/user-info-dialog/user-info-image-upload/user-info-image-upload.tsx
@@ -56,10 +56,19 @@ const ImageOverlay = () => (
     </defs>
     <rect
       fill="black"
-      fillOpacity={0.7}
+      fillOpacity={0.4}
       width="100%"
       height="100%"
       mask="url(#hole)"
+    />
+    <circle
+      cx="50%"
+      cy="50%"
+      r="50%"
+      fill="transparent"
+      stroke="white"
+      strokeWidth="1px"
+      strokeOpacity={0.7}
     />
   </svg>
 )

--- a/ui/src/components/header/user-info-dialog/user-info-image-upload/user-info-image-upload.tsx
+++ b/ui/src/components/header/user-info-dialog/user-info-image-upload/user-info-image-upload.tsx
@@ -68,7 +68,6 @@ const ImageOverlay = () => (
       fill="transparent"
       stroke="white"
       strokeWidth="1px"
-      strokeOpacity={0.7}
     />
   </svg>
 )

--- a/ui/src/components/header/user-info-dialog/user-info-image-upload/user-info-image-upload.tsx
+++ b/ui/src/components/header/user-info-dialog/user-info-image-upload/user-info-image-upload.tsx
@@ -1,6 +1,6 @@
-import classNames from 'classnames'
 import { FileInput } from 'design-system/components/file-input/file-input'
 import { FileInputAccept } from 'design-system/components/file-input/types'
+import { useState } from 'react'
 import { UserInfo } from 'utils/user/types'
 import styles from './user-info-image-upload.module.scss'
 
@@ -13,6 +13,7 @@ export const UserInfoImageUpload = ({
   userInfo: UserInfo
   onChange: (file: File | null) => void
 }) => {
+  const [_size, setSize] = useState<{ width: number; height: number }>()
   const imageUrl = (() => {
     if (file) {
       return URL.createObjectURL(file)
@@ -24,22 +25,50 @@ export const UserInfoImageUpload = ({
   })()
 
   return (
-    <div className={styles.container}>
-      <div className={styles.content}>
-        {imageUrl ? <img src={imageUrl} /> : null}
-        <div
-          className={classNames(styles.overlay, {
-            [styles.hasImage]: !!imageUrl,
-          })}
-        >
-          <FileInput
-            accept={FileInputAccept.Images}
-            label="Choose image"
-            name="user-image"
-            onChange={onChange}
-          />
+    <>
+      <div className={styles.container}>
+        <div className={styles.content}>
+          {imageUrl ? (
+            <>
+              <img
+                src={imageUrl}
+                onLoad={(e) => {
+                  const width = e.currentTarget.naturalWidth
+                  const height = e.currentTarget.naturalHeight
+                  setSize({ width, height })
+                }}
+              />
+              <ImageOverlay />
+            </>
+          ) : (
+            <span>No image</span>
+          )}
         </div>
       </div>
-    </div>
+      <FileInput
+        accept={FileInputAccept.Images}
+        label="Choose image"
+        name="user-image"
+        onChange={onChange}
+      />
+    </>
   )
 }
+
+const ImageOverlay = () => (
+  <svg className={styles.overlay}>
+    <defs>
+      <mask id="hole">
+        <rect width="100%" height="100%" fill="white" />
+        <circle cx="50%" cy="50%" r="50%" fill="black" />
+      </mask>
+    </defs>
+    <rect
+      fill="black"
+      fillOpacity={0.7}
+      width="100%"
+      height="100%"
+      mask="url(#hole)"
+    />
+  </svg>
+)

--- a/ui/src/design-system/components/file-input/file-input.module.scss
+++ b/ui/src/design-system/components/file-input/file-input.module.scss
@@ -3,9 +3,9 @@
 
 .container {
   display: flex;
-  flex-direction: column;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
+  margin-top: 8px;
   gap: 16px;
 }
 


### PR DESCRIPTION
Update profile image UI to make it a bit more clear:
- Skip image hover effect
- Move controls below image and have them always visible
- Add preview effect to show how image will be cropped
- Tweak button copy from "Choose image" to "Change image" if image is already set

After changes:
<img width="764" alt="Screenshot 2023-09-18 at 17 29 53" src="https://github.com/RolnickLab/ami-platform/assets/11680517/ef3e8039-28b0-4e22-b591-10726a02def6">

Before changes:
<img width="778" alt="Screenshot 2023-09-18 at 17 30 18" src="https://github.com/RolnickLab/ami-platform/assets/11680517/c7e2bbde-5565-4e10-ba24-eb977fc4e85f">
