### PR TITLE
Fix bug with "About" and "Help" buttons

### DIFF
--- a/ui/src/components/header/header.tsx
+++ b/ui/src/components/header/header.tsx
@@ -42,7 +42,7 @@ export const Header = () => {
               label="Logout"
               theme={ButtonTheme.Plain}
               loading={isLogoutLoading}
-              onClick={logout}
+              onClick={() => logout()}
             />
             <UserInfoDialog />
           </>

--- a/ui/src/design-system/components/button/button.tsx
+++ b/ui/src/design-system/components/button/button.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames'
-import { forwardRef } from 'react'
+import { forwardRef, MouseEvent } from 'react'
 import { Icon, IconTheme, IconType } from '../icon/icon'
 import styles from './button.module.scss'
 
@@ -18,7 +18,7 @@ interface ButtonProps {
   loading?: boolean
   theme?: ButtonTheme
   type?: 'submit' | 'button'
-  onClick?: () => void
+  onClick?: (e: MouseEvent) => void
 }
 
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
@@ -51,11 +51,11 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         })}
         disabled={disabled}
         type={type}
-        onClick={() => {
+        onClick={(e) => {
           if (loading) {
             return
           }
-          onClick?.()
+          onClick?.(e)
         }}
         {...rest}
       >


### PR DESCRIPTION
Fixing small bug in header where "About" and "Help" were not possible to click. Related to click event not being passed from button component, which caused a dialog error.