### PR TITLE
[Minor]: Handle sessions with no captures

### DIFF
--- a/ui/src/data-services/models/session-details.ts
+++ b/ui/src/data-services/models/session-details.ts
@@ -16,19 +16,21 @@ interface SummaryData {
 }
 
 export class SessionDetails extends Session {
-  private readonly _firstCapture: Capture
+  private readonly _firstCapture?: Capture
 
   public constructor(event: ServerEventDetails) {
     super(event)
 
-    this._firstCapture = new Capture(event.first_capture)
+    if (event.first_capture) {
+      this._firstCapture = new Capture(event.first_capture)
+    }
   }
 
   get captureOffset(): number | undefined {
     return this._event.capture_page_offset
   }
 
-  get firstCapture(): Capture {
+  get firstCapture(): Capture | undefined {
     return this._firstCapture
   }
 

--- a/ui/src/pages/session-details/playback/playback.tsx
+++ b/ui/src/pages/session-details/playback/playback.tsx
@@ -19,6 +19,10 @@ export const Playback = ({ session }: { session: SessionDetails }) => {
   const { activeCapture, setActiveCapture } = useActiveCapture(captures)
   const [showOverlay, setShowOverlay] = useState(false)
 
+  if (!session.firstCapture) {
+    return null
+  }
+
   return (
     <div className={styles.wrapper}>
       <div


### PR DESCRIPTION
When experimenting with uploading and delete captures, I noticed BE might can return sessions where "first capture" has value null. In this PR we prepare FE on this scenario.

**Before:**
Crash!

**After:**
<img width="1502" alt="Screenshot 2023-10-16 at 15 38 34" src="https://github.com/RolnickLab/ami-platform/assets/11680517/9ef6a08c-cf24-4109-b10b-b97c595e9f12">
