### PR TITLE
Cleanup translations

### DIFF
--- a/ui/src/components/form/delete-form/delete-form.tsx
+++ b/ui/src/components/form/delete-form/delete-form.tsx
@@ -1,5 +1,6 @@
 import { Button, ButtonTheme } from 'design-system/components/button/button'
 import { IconType } from 'design-system/components/icon/icon'
+import { STRING, translate } from 'utils/language'
 import { parseServerError } from 'utils/parseServerError/parseServerError'
 import { FormError } from '../layout/layout'
 import styles from './delete-form.module.scss'
@@ -27,14 +28,18 @@ export const DeleteForm = ({
         <FormError message={errorMessage} style={{ padding: '8px 16px' }} />
       ) : null}
       <div className={styles.content}>
-        <span className={styles.title}>Delete {type}</span>
+        <span className={styles.title}>
+          {translate(STRING.ENTITY_DELETE, { type })}
+        </span>
         <span className={styles.description}>
-          Are you sure you want to delete this {type}?
+          {translate(STRING.MESSAGE_DELETE_CONFIRM, { type })}
         </span>
         <div className={styles.formActions}>
-          <Button label="Cancel" onClick={onCancel} />
+          <Button label={translate(STRING.CANCEL)} onClick={onCancel} />
           <Button
-            label={isSuccess ? 'Deleted' : 'Delete'}
+            label={
+              isSuccess ? translate(STRING.DELETED) : translate(STRING.DELETE)
+            }
             icon={isSuccess ? IconType.RadixCheck : undefined}
             theme={ButtonTheme.Destructive}
             loading={isLoading}

--- a/ui/src/components/header/header.tsx
+++ b/ui/src/components/header/header.tsx
@@ -4,6 +4,7 @@ import { usePages } from 'data-services/hooks/pages/usePages'
 import { Button, ButtonTheme } from 'design-system/components/button/button'
 import { Link, useLocation, useNavigate } from 'react-router-dom'
 import { APP_ROUTES } from 'utils/constants'
+import { STRING, translate } from 'utils/language'
 import { useUser } from 'utils/user/userContext'
 import ami from './ami.png'
 import styles from './header.module.scss'
@@ -32,14 +33,14 @@ export const Header = () => {
           <InfoDialog key={page.id} name={page.name} slug={page.slug} />
         ))}
         <Button
-          label="Sign up"
+          label={translate(STRING.SIGN_UP)}
           theme={ButtonTheme.Plain}
           onClick={() => navigate(APP_ROUTES.SIGN_UP)}
         />
         {user.loggedIn ? (
           <>
             <Button
-              label="Logout"
+              label={translate(STRING.LOGOUT)}
               theme={ButtonTheme.Plain}
               loading={isLogoutLoading}
               onClick={() => logout()}
@@ -48,7 +49,7 @@ export const Header = () => {
           </>
         ) : (
           <Button
-            label="Login"
+            label={translate(STRING.LOGIN)}
             theme={ButtonTheme.Plain}
             onClick={() =>
               navigate(APP_ROUTES.LOGIN, { state: { to: location.pathname } })

--- a/ui/src/components/header/user-info-dialog/user-info-dialog.tsx
+++ b/ui/src/components/header/user-info-dialog/user-info-dialog.tsx
@@ -30,7 +30,11 @@ export const UserInfoDialog = () => {
         </div>
       </Dialog.Trigger>
       <Dialog.Content ariaCloselabel={translate(STRING.CLOSE)}>
-        <Dialog.Header title="Edit user info" />
+        <Dialog.Header
+          title={translate(STRING.ENTITY_EDIT, {
+            type: translate(STRING.USER_INFO).toLowerCase(),
+          })}
+        />
         <div className={styles.content}>
           <UserInfoForm userInfo={userInfo} />
         </div>
@@ -51,7 +55,7 @@ const UserInfoButtonContent = ({ userInfo }: { userInfo: UserInfo }) => {
   })()
 
   if (userInfo.image) {
-    return <img alt="Profile image" src={userInfo.image} />
+    return <img alt="" src={userInfo.image} />
   }
 
   return <span>{name.charAt(0)}</span>

--- a/ui/src/components/header/user-info-dialog/user-info-form/user-info-form.tsx
+++ b/ui/src/components/header/user-info-dialog/user-info-form/user-info-form.tsx
@@ -26,13 +26,17 @@ interface UserInfoFormValues {
 
 const config: FormConfig = {
   name: {
-    label: 'Name',
+    label: translate(STRING.FIELD_LABEL_NAME),
   },
   image: {
-    label: 'Image',
-    description: `The image must smaller than ${bytesToMB(
-      IMAGE_MAX_SIZE
-    )} MB. Valid formats are PNG, GIF and JPEG.`,
+    label: translate(STRING.FIELD_LABEL_IMAGE),
+    description: [
+      translate(STRING.MESSAGE_IMAGE_SIZE, {
+        value: bytesToMB(IMAGE_MAX_SIZE),
+        unit: 'MB',
+      }),
+      translate(STRING.MESSAGE_IMAGE_FORMAT),
+    ].join('\n'),
     rules: {
       validate: (file: File) => {
         if (file) {
@@ -62,14 +66,21 @@ export const UserInfoForm = ({ userInfo }: { userInfo: UserInfo }) => {
   return (
     <form onSubmit={handleSubmit((values) => updateUserInfo(values))}>
       {errorMessage && (
-        <FormError inDialog intro="Could not save" message={errorMessage} />
+        <FormError
+          inDialog
+          intro={translate(STRING.MESSAGE_COULD_NOT_SAVE)}
+          message={errorMessage}
+        />
       )}
       <FormSection>
         <FormRow>
-          <InputValue label="Email" value={userInfo.email} />
           <InputValue
-            label="Password"
-            value="Contact an administrator to change your email or password."
+            label={translate(STRING.FIELD_LABEL_NAME)}
+            value={userInfo.email}
+          />
+          <InputValue
+            label={translate(STRING.FIELD_LABEL_PASSWORD)}
+            value={translate(STRING.MESSAGE_CHANGE_PASSWORD)}
           />
         </FormRow>
         <FormRow>

--- a/ui/src/components/header/user-info-dialog/user-info-image-upload/user-info-image-upload.tsx
+++ b/ui/src/components/header/user-info-dialog/user-info-image-upload/user-info-image-upload.tsx
@@ -1,6 +1,7 @@
 import { Button } from 'design-system/components/button/button'
 import { FileInput } from 'design-system/components/file-input/file-input'
 import { FileInputAccept } from 'design-system/components/file-input/types'
+import { STRING, translate } from 'utils/language'
 import { UserInfo } from 'utils/user/types'
 import styles from './user-info-image-upload.module.scss'
 
@@ -33,7 +34,7 @@ export const UserInfoImageUpload = ({
               <ImageOverlay />
             </>
           ) : (
-            <span>No image</span>
+            <span>{translate(STRING.MESSAGE_NO_IMAGE)}</span>
           )}
         </div>
       </div>
@@ -43,7 +44,11 @@ export const UserInfoImageUpload = ({
         renderInput={(props) => (
           <Button
             {...props}
-            label={imageUrl ? 'Change image' : 'Choose image'}
+            label={
+              imageUrl
+                ? translate(STRING.CHANGE_IMAGE)
+                : translate(STRING.CHOOSE_IMAGE)
+            }
           />
         )}
         withClear

--- a/ui/src/design-system/components/file-input/file-input.tsx
+++ b/ui/src/design-system/components/file-input/file-input.tsx
@@ -1,4 +1,5 @@
 import { useRef } from 'react'
+import { STRING, translate } from 'utils/language'
 import { Button, ButtonTheme } from '../button/button'
 import styles from './file-input.module.scss'
 import { FileInputAccept } from './types'
@@ -56,7 +57,7 @@ export const FileInput = ({
       {renderInput({ loading, onClick: () => inputRef.current?.click() })}
       {withClear && (
         <Button
-          label="Clear"
+          label={translate(STRING.CLEAR)}
           theme={ButtonTheme.Plain}
           onClick={() => {
             if (inputRef.current) {

--- a/ui/src/design-system/components/identification/identification-summary/identification-summary.tsx
+++ b/ui/src/design-system/components/identification/identification-summary/identification-summary.tsx
@@ -1,4 +1,5 @@
 import { ReactNode } from 'react'
+import { STRING, translate } from 'utils/language'
 import { Icon, IconTheme, IconType } from '../../icon/icon'
 import styles from './identification-summary.module.scss'
 
@@ -19,7 +20,7 @@ export const IdentificationSummary = ({
       {user ? (
         <div className={styles.profileImage}>
           {user.image ? (
-            <img src={user.image} alt="User profile image" />
+            <img src={user.image} alt="" />
           ) : (
             <Icon
               type={IconType.Photograph}
@@ -32,7 +33,7 @@ export const IdentificationSummary = ({
         <Icon type={IconType.BatchId} theme={IconTheme.Primary} size={16} />
       )}
       <span className={styles.username}>
-        {user?.name ?? 'Machine suggestion'}
+        {user?.name ?? translate(STRING.MACHINE_SUGGESTION)}
       </span>
     </div>
     {children}

--- a/ui/src/pages/auth/login.tsx
+++ b/ui/src/pages/auth/login.tsx
@@ -6,6 +6,7 @@ import { Button, ButtonTheme } from 'design-system/components/button/button'
 import { useForm } from 'react-hook-form'
 import { Link, useLocation, useNavigate } from 'react-router-dom'
 import { APP_ROUTES } from 'utils/constants'
+import { STRING, translate } from 'utils/language'
 import { useFormError } from 'utils/useFormError'
 import styles from './auth.module.scss'
 
@@ -16,13 +17,13 @@ interface LoginFormValues {
 
 const config: FormConfig = {
   email: {
-    label: 'Email',
+    label: translate(STRING.FIELD_LABEL_EMAIL),
     rules: {
       required: true,
     },
   },
   password: {
-    label: 'Password',
+    label: translate(STRING.FIELD_LABEL_PASSWORD),
     rules: {
       required: true,
     },
@@ -46,7 +47,7 @@ export const Login = () => {
 
   return (
     <>
-      <h1 className={styles.title}>Login</h1>
+      <h1 className={styles.title}>{translate(STRING.LOGIN)}</h1>
       <form
         className={styles.form}
         onSubmit={handleSubmit((values) => login(values))}
@@ -59,7 +60,7 @@ export const Login = () => {
           control={control}
         />
         <Button
-          label="Login"
+          label={translate(STRING.LOGIN)}
           type="submit"
           theme={ButtonTheme.Success}
           loading={isLoading}
@@ -70,11 +71,14 @@ export const Login = () => {
           </p>
         )}
         <p className={styles.text}>
-          No account yet? <Link to={APP_ROUTES.SIGN_UP}>Sign up</Link>
+          {translate(STRING.MESSAGE_NO_ACCOUNT_YET)}{' '}
+          <Link to={APP_ROUTES.SIGN_UP}>{translate(STRING.SIGN_UP)}</Link>
         </p>
-        <p className={classNames(styles.text, styles.divider)}>OR</p>
+        <p className={classNames(styles.text, styles.divider)}>
+          {translate(STRING.OR).toUpperCase()}
+        </p>
         <Button
-          label="View public projects"
+          label={translate(STRING.VIEW_PUBLIC_PROJECTS)}
           type="button"
           theme={ButtonTheme.Default}
           onClick={() => navigate(APP_ROUTES.HOME)}

--- a/ui/src/pages/auth/sign-up.tsx
+++ b/ui/src/pages/auth/sign-up.tsx
@@ -8,6 +8,7 @@ import { useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { Link, useNavigate } from 'react-router-dom'
 import { APP_ROUTES } from 'utils/constants'
+import { STRING, translate } from 'utils/language'
 import { useFormError } from 'utils/useFormError'
 import styles from './auth.module.scss'
 
@@ -18,15 +19,14 @@ interface SignUpFormValues {
 
 const config: FormConfig = {
   email: {
-    label: 'Email',
+    label: translate(STRING.FIELD_LABEL_EMAIL),
     rules: {
       required: true,
     },
   },
   password: {
-    label: 'Password',
-    description:
-      'The password must contain at least 8 characters and cannot be entirely numeric.',
+    label: translate(STRING.FIELD_LABEL_PASSWORD),
+    description: translate(STRING.MESSAGE_PASSWORD_FORMAT),
     rules: {
       required: true,
       minLength: 8,
@@ -57,7 +57,7 @@ export const SignUp = () => {
 
   return (
     <>
-      <h1 className={styles.title}>Sign up</h1>
+      <h1 className={styles.title}>{translate(STRING.SIGN_UP)}</h1>
       <form
         className={styles.form}
         onSubmit={handleSubmit((values) =>
@@ -72,7 +72,7 @@ export const SignUp = () => {
           control={control}
         />
         <Button
-          label="Sign up"
+          label={translate(STRING.SIGN_UP)}
           type="submit"
           theme={ButtonTheme.Success}
           loading={isLoading}
@@ -90,21 +90,23 @@ export const SignUp = () => {
                 size={12}
                 theme={IconTheme.Success}
               />
-              <span>Signed up successfully!</span>
+              <span>{translate(STRING.MESSAGE_SIGNED_UP)}</span>
             </>
           ) : (
-            <span>Already have an account?</span>
+            <span>{translate(STRING.MESSAGE_HAS_ACCOUNT)}</span>
           )}
           <Link
             to={APP_ROUTES.LOGIN}
             state={isSuccess ? { email: signedUpEmail } : undefined}
           >
-            Login
+            {translate(STRING.LOGIN)}
           </Link>
         </p>
-        <p className={classNames(styles.text, styles.divider)}>OR</p>
+        <p className={classNames(styles.text, styles.divider)}>
+          {translate(STRING.OR).toUpperCase()}
+        </p>
         <Button
-          label="View public projects"
+          label={translate(STRING.VIEW_PUBLIC_PROJECTS)}
           type="button"
           theme={ButtonTheme.Default}
           onClick={() => navigate(APP_ROUTES.HOME)}

--- a/ui/src/pages/deployment-details/delete-deployment-dialog.tsx
+++ b/ui/src/pages/deployment-details/delete-deployment-dialog.tsx
@@ -21,7 +21,7 @@ export const DeleteDeploymentDialog = ({ id }: { id: string }) => {
         <div className={classNames(styles.content, styles.compact)}>
           <DeleteForm
             error={error}
-            type="deployment"
+            type={translate(STRING.ENTITY_TYPE_DEPLOYMENT)}
             isLoading={isLoading}
             isSuccess={isSuccess}
             onCancel={() => setIsOpen(false)}

--- a/ui/src/pages/deployment-details/deployment-details-dialog.tsx
+++ b/ui/src/pages/deployment-details/deployment-details-dialog.tsx
@@ -2,6 +2,7 @@ import { useDeploymentDetails } from 'data-services/hooks/deployments/useDeploym
 import { useUpdateDeployment } from 'data-services/hooks/deployments/useUpdateDeployment'
 import { DeploymentDetails } from 'data-services/models/deployment-details'
 import * as Dialog from 'design-system/components/dialog/dialog'
+import _ from 'lodash'
 import { useEffect, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { APP_ROUTES } from 'utils/constants'
@@ -59,7 +60,9 @@ const DeploymentDetailsDialogContent = ({
       {!isEditing ? (
         <DeploymentDetailsInfo
           deployment={deployment}
-          title={translate(STRING.DIALOG_DEPLOYMENT_DETAILS)}
+          title={translate(STRING.ENTITY_DETAILS, {
+            type: _.capitalize(translate(STRING.ENTITY_TYPE_DEPLOYMENT)),
+          })}
           onEditClick={() => setIsEditing(true)}
         />
       ) : (
@@ -68,7 +71,9 @@ const DeploymentDetailsDialogContent = ({
           serverError={error}
           isLoading={isLoading}
           startValid
-          title={translate(STRING.DIALOG_EDIT_DEPLOYMENT)}
+          title={translate(STRING.ENTITY_EDIT, {
+            type: translate(STRING.ENTITY_TYPE_DEPLOYMENT),
+          })}
           onCancelClick={() => setIsEditing(false)}
           onSubmit={(data) => {
             updateDeployment(data)

--- a/ui/src/pages/deployment-details/deployment-details-form/deployment-details-form.tsx
+++ b/ui/src/pages/deployment-details/deployment-details-form/deployment-details-form.tsx
@@ -154,7 +154,11 @@ const FormError = ({ error }: { error: unknown }) => {
   const errorMessage = useFormError({ error })
 
   return errorMessage ? (
-    <_FormError inDialog intro="Could not save" message={errorMessage} />
+    <_FormError
+      inDialog
+      intro={translate(STRING.MESSAGE_COULD_NOT_SAVE)}
+      message={errorMessage}
+    />
   ) : null
 }
 

--- a/ui/src/pages/deployment-details/deployment-details-form/section-example-captures/section-example-captures.tsx
+++ b/ui/src/pages/deployment-details/deployment-details-form/section-example-captures/section-example-captures.tsx
@@ -216,7 +216,7 @@ const DeleteCaptureDialog = ({ id }: { id: string }) => {
         <div className={styles.deleteDialog}>
           <DeleteForm
             error={error}
-            type={translate(STRING.CAPTURE)}
+            type={translate(STRING.ENTITY_TYPE_CAPTURE)}
             isLoading={isLoading}
             isSuccess={isSuccess}
             onCancel={() => setIsOpen(false)}

--- a/ui/src/pages/deployment-details/deployment-details-form/section-example-captures/section-example-captures.tsx
+++ b/ui/src/pages/deployment-details/deployment-details-form/section-example-captures/section-example-captures.tsx
@@ -27,21 +27,17 @@ export const CAPTURE_CONFIG = {
   RATIO: 16 / 9,
 }
 
-// TODO: Move to translations when we are happy with the copy
-export const COPY = {
-  CAPTURE: 'capture',
-  DESCRIPTIONS: [
-    `A maximum of ${CAPTURE_CONFIG.NUM_CAPTURES} captures can be uploaded.`,
-    `The image must smaller than ${bytesToMB(CAPTURE_CONFIG.MAX_SIZE)} MB.`,
-    'Valid formats are PNG, GIF and JPEG.',
-    'Image filenames must contain a timestamp in the format YYYYMMDDHHMMSS (e.g. 20210101120000-snapshot.jpg).',
-  ],
-  FIELD_LABEL_UPLOADED_CAPTURES: 'Manually uploaded captures',
-  MESSAGE_CAPTURE_UPLOAD_HIDDEN:
-    'Deployment must be saved before uploading captures.',
-  MESSAGE_CAPTURE_LIMIT: `To upload more than ${CAPTURE_CONFIG.NUM_CAPTURES} images you must configure a data source.`,
-  RETRY: 'Retry',
-}
+const CAPTURE_FIELD_DESCRIPTION = [
+  translate(STRING.MESSAGE_CAPTURE_LIMIT, {
+    numCaptures: CAPTURE_CONFIG.NUM_CAPTURES,
+  }),
+  translate(STRING.MESSAGE_IMAGE_SIZE, {
+    value: bytesToMB(CAPTURE_CONFIG.MAX_SIZE),
+    unit: 'MB',
+  }),
+  translate(STRING.MESSAGE_IMAGE_FORMAT),
+  translate(STRING.MESSAGE_CAPTURE_FILENAME),
+].join('\n')
 
 export const SectionExampleCaptures = ({
   deployment,
@@ -53,8 +49,8 @@ export const SectionExampleCaptures = ({
   if (!deployment.createdAt) {
     return (
       <InputContent
-        label={COPY.FIELD_LABEL_UPLOADED_CAPTURES}
-        description={COPY.MESSAGE_CAPTURE_UPLOAD_HIDDEN}
+        label={translate(STRING.FIELD_LABEL_UPLOADED_CAPTURES)}
+        description={translate(STRING.MESSAGE_CAPTURE_UPLOAD_HIDDEN)}
       />
     )
   }
@@ -65,8 +61,8 @@ export const SectionExampleCaptures = ({
 
   return (
     <InputContent
-      label={COPY.FIELD_LABEL_UPLOADED_CAPTURES}
-      description={COPY.DESCRIPTIONS.join('\n')}
+      label={translate(STRING.FIELD_LABEL_UPLOADED_CAPTURES)}
+      description={CAPTURE_FIELD_DESCRIPTION}
     >
       <div className={styles.collection}>
         {deployment.exampleCaptures.map((exampelCapture) => (
@@ -181,7 +177,7 @@ const AddedExampleCapture = ({
               {allowRetry ? (
                 <Button
                   icon={IconType.Error}
-                  label={COPY.RETRY}
+                  label={translate(STRING.RETRY)}
                   theme={ButtonTheme.Error}
                   onClick={() => {
                     uploadCapture({ deploymentId, file })
@@ -220,7 +216,7 @@ const DeleteCaptureDialog = ({ id }: { id: string }) => {
         <div className={styles.deleteDialog}>
           <DeleteForm
             error={error}
-            type={COPY.CAPTURE}
+            type={translate(STRING.CAPTURE)}
             isLoading={isLoading}
             isSuccess={isSuccess}
             onCancel={() => setIsOpen(false)}

--- a/ui/src/pages/deployment-details/deployment-details-form/section-example-captures/section-example-captures.tsx
+++ b/ui/src/pages/deployment-details/deployment-details-form/section-example-captures/section-example-captures.tsx
@@ -22,7 +22,7 @@ import styles from './section-example-captures.module.scss'
 import { useCaptureError } from './useCaptureError'
 
 export const CAPTURE_CONFIG = {
-  MAX_SIZE: 1024 * 1024 * 1, // 10MB
+  MAX_SIZE: 1024 * 1024 * 10, // 10MB
   NUM_CAPTURES: 20,
   RATIO: 16 / 9,
 }

--- a/ui/src/pages/deployment-details/deployment-details-form/section-example-captures/useCaptureError.ts
+++ b/ui/src/pages/deployment-details/deployment-details-form/section-example-captures/useCaptureError.ts
@@ -1,6 +1,6 @@
 import { STRING, translate } from 'utils/language'
 import { parseServerError } from 'utils/parseServerError/parseServerError'
-import { CAPTURE_CONFIG, COPY } from './section-example-captures'
+import { CAPTURE_CONFIG } from './section-example-captures'
 
 export const useCaptureError = ({
   error,
@@ -13,7 +13,9 @@ export const useCaptureError = ({
 }) => {
   const clientError = (() => {
     if (index >= CAPTURE_CONFIG.NUM_CAPTURES) {
-      return COPY.MESSAGE_CAPTURE_LIMIT
+      return translate(STRING.MESSAGE_CAPTURE_TOO_MANY, {
+        numCaptures: CAPTURE_CONFIG.NUM_CAPTURES,
+      })
     }
 
     if (file.size > CAPTURE_CONFIG.MAX_SIZE) {

--- a/ui/src/pages/deployment-details/new-deployment-dialog.tsx
+++ b/ui/src/pages/deployment-details/new-deployment-dialog.tsx
@@ -17,20 +17,21 @@ export const NewDeploymentDialog = () => {
   const [isOpen, setIsOpen] = useState(false)
   const { createDeployment, isLoading, error } = useCreateDeployment()
 
+  const label = translate(STRING.ENTITY_CREATE, {
+    type: translate(STRING.ENTITY_TYPE_DEPLOYMENT),
+  })
+
   return (
     <Dialog.Root open={isOpen} onOpenChange={setIsOpen}>
       <Dialog.Trigger>
-        <Button
-          label={translate(STRING.DIALOG_NEW_DEPLOYMENT)}
-          icon={IconType.Plus}
-        />
+        <Button label={label} icon={IconType.Plus} />
       </Dialog.Trigger>
       <Dialog.Content ariaCloselabel={translate(STRING.CLOSE)}>
         <DeploymentDetailsForm
           deployment={newDeployment}
           serverError={error}
           isLoading={isLoading}
-          title={translate(STRING.DIALOG_NEW_DEPLOYMENT)}
+          title={label}
           onCancelClick={() => setIsOpen(false)}
           onSubmit={async (data) => {
             await createDeployment({ ...data, projectId })

--- a/ui/src/pages/occurrence-details/agree/agree.tsx
+++ b/ui/src/pages/occurrence-details/agree/agree.tsx
@@ -2,6 +2,7 @@ import { useCreateIdentification } from 'data-services/hooks/identifications/use
 import { Button, ButtonTheme } from 'design-system/components/button/button'
 import { IconType } from 'design-system/components/icon/icon'
 import { useEffect } from 'react'
+import { STRING, translate } from 'utils/language'
 
 interface AgreeProps {
   agreed?: boolean
@@ -30,13 +31,17 @@ export const Agree = ({
 
   if (isSuccess || agreed) {
     return (
-      <Button label="Agreed" icon={IconType.RadixCheck} theme={buttonTheme} />
+      <Button
+        label={translate(STRING.AGREED)}
+        icon={IconType.RadixCheck}
+        theme={buttonTheme}
+      />
     )
   }
 
   return (
     <Button
-      label="Agree"
+      label={translate(STRING.AGREE)}
       loading={isLoading}
       theme={buttonTheme}
       onClick={() =>

--- a/ui/src/pages/occurrence-details/identification-card/identification-card.tsx
+++ b/ui/src/pages/occurrence-details/identification-card/identification-card.tsx
@@ -12,6 +12,7 @@ import { useState } from 'react'
 import { useParams } from 'react-router-dom'
 import { APP_ROUTES } from 'utils/constants'
 import { getAppRoute } from 'utils/getAppRoute'
+import { STRING, translate } from 'utils/language'
 import { UserInfo, UserPermission } from 'utils/user/types'
 import { Agree } from '../agree/agree'
 import { userAgreed } from '../agree/userAgreed'
@@ -56,7 +57,9 @@ export const IdentificationCard = ({
     <div className={styles.identificationCard}>
       <div className={styles.content}>
         <IdentificationSummary user={user}>
-          {identification.applied && <StatusLabel label="ID applied" />}
+          {identification.applied && (
+            <StatusLabel label={translate(STRING.ID_APPLIED)} />
+          )}
           <TaxonInfo
             overridden={identification.overridden}
             taxon={identification.taxon}

--- a/ui/src/pages/occurrence-details/occurrence-details.tsx
+++ b/ui/src/pages/occurrence-details/occurrence-details.tsx
@@ -134,8 +134,12 @@ export const OccurrenceDetails = ({
           <Tooltip
             content={
               occurrence.determinationVerified
-                ? `Verified by\n${occurrence.determinationVerifiedBy}`
-                : `Machine prediction\nscore ${occurrence.determinationScore}`
+                ? translate(STRING.VERIFIED_BY, {
+                    name: occurrence.determinationVerifiedBy as string,
+                  })
+                : translate(STRING.MACHINE_PREDICTION_SCORE, {
+                    score: occurrence.determinationScore,
+                  })
             }
           >
             <IdentificationStatus
@@ -160,7 +164,7 @@ export const OccurrenceDetails = ({
                 taxonId={occurrence.determinationTaxon.id}
               />
               <Button
-                label="Suggest ID"
+                label={translate(STRING.SUGGEST_ID)}
                 icon={IconType.ShieldAlert}
                 onClick={() => {
                   setSelectedTab(TABS.IDENTIFICATION)

--- a/ui/src/pages/occurrence-details/suggest-id/suggest-id.tsx
+++ b/ui/src/pages/occurrence-details/suggest-id/suggest-id.tsx
@@ -8,6 +8,7 @@ import { RefObject, useState } from 'react'
 import { useParams } from 'react-router'
 import { APP_ROUTES } from 'utils/constants'
 import { getAppRoute } from 'utils/getAppRoute'
+import { STRING, translate } from 'utils/language'
 import { parseServerError } from 'utils/parseServerError/parseServerError'
 import { StatusLabel } from '../status-label/status-label'
 import { TaxonSearch } from '../taxon-search/taxon-search'
@@ -38,8 +39,8 @@ export const SuggestId = ({
         <FormError message={formError} style={{ padding: '8px 16px' }} />
       )}
       <div className={styles.content}>
-        <StatusLabel label="New ID" />
-        <InputContent label="Taxon">
+        <StatusLabel label={translate(STRING.NEW_ID)} />
+        <InputContent label={translate(STRING.FIELD_LABEL_TAXON)}>
           <div className={styles.taxonActions}>
             <TaxonSearch
               containerRef={containerRef}
@@ -62,11 +63,15 @@ export const SuggestId = ({
             />
           )}
         </InputContent>
-        <Input label="Comment" name="comment" disabled />
+        <Input
+          label={translate(STRING.FIELD_LABEL_COMMENT)}
+          name="comment"
+          disabled
+        />
         <div className={styles.formActions}>
-          <Button label="Cancel" onClick={onCancel} />
+          <Button label={translate(STRING.CANCEL)} onClick={onCancel} />
           <Button
-            label="Submit"
+            label={translate(STRING.SUBMIT)}
             theme={ButtonTheme.Success}
             loading={isLoading}
             disabled={!taxon}

--- a/ui/src/pages/occurrences/occurrence-columns.tsx
+++ b/ui/src/pages/occurrences/occurrence-columns.tsx
@@ -125,8 +125,12 @@ const TaxonCell = ({
           <Tooltip
             content={
               item.determinationVerified
-                ? `Verified by\n${item.determinationVerifiedBy}`
-                : `Machine prediction\nscore ${item.determinationScore}`
+                ? translate(STRING.VERIFIED_BY, {
+                    name: item.determinationVerifiedBy as string,
+                  })
+                : translate(STRING.MACHINE_PREDICTION_SCORE, {
+                    score: item.determinationScore,
+                  })
             }
           >
             <IdentificationStatus
@@ -155,7 +159,7 @@ const TaxonCell = ({
                 occurrenceId={item.id}
                 taxonId={item.determinationTaxon.id}
               />
-              <Tooltip content="Suggest ID">
+              <Tooltip content={translate(STRING.SUGGEST_ID)}>
                 <IconButton
                   icon={IconType.ShieldAlert}
                   onClick={() =>

--- a/ui/src/pages/project-details/delete-project-dialog.tsx
+++ b/ui/src/pages/project-details/delete-project-dialog.tsx
@@ -21,7 +21,7 @@ export const DeleteProjectDialog = ({ id }: { id: string }) => {
         <div className={classNames(styles.content, styles.compact)}>
           <DeleteForm
             error={error}
-            type="project"
+            type={translate(STRING.ENTITY_TYPE_PROJECT)}
             isLoading={isLoading}
             isSuccess={isSuccess}
             onCancel={() => setIsOpen(false)}

--- a/ui/src/pages/project-details/edit-project-dialog.tsx
+++ b/ui/src/pages/project-details/edit-project-dialog.tsx
@@ -21,7 +21,11 @@ export const EditProjectDialog = ({ id }: { id: string }) => {
         ariaCloselabel={translate(STRING.CLOSE)}
         isLoading={!isLoaded}
       >
-        <Dialog.Header title={translate(STRING.DIALOG_EDIT_PROJECT)} />
+        <Dialog.Header
+          title={translate(STRING.ENTITY_EDIT, {
+            type: translate(STRING.ENTITY_TYPE_PROJECT),
+          })}
+        />
         <div className={styles.content}>
           <EditProjectDialogContent
             id={id}

--- a/ui/src/pages/project-details/new-project-dialog.tsx
+++ b/ui/src/pages/project-details/new-project-dialog.tsx
@@ -22,17 +22,21 @@ export const NewProjectDialog = () => {
     }, CLOSE_TIMEOUT)
   )
 
+  const label = translate(STRING.ENTITY_CREATE, {
+    type: translate(STRING.ENTITY_TYPE_PROJECT),
+  })
+
   return (
     <Dialog.Root open={isOpen} onOpenChange={setIsOpen}>
       <Dialog.Trigger>
         <Button
-          label={translate(STRING.DIALOG_NEW_PROJECT)}
+          label={label}
           icon={IconType.Plus}
           theme={ButtonTheme.Default}
         />
       </Dialog.Trigger>
       <Dialog.Content ariaCloselabel={translate(STRING.CLOSE)}>
-        <Dialog.Header title={translate(STRING.DIALOG_NEW_PROJECT)} />
+        <Dialog.Header title={label} />
         <div className={styles.content}>
           <ProjectDetailsForm
             project={newProject}

--- a/ui/src/pages/project-details/project-details-form.tsx
+++ b/ui/src/pages/project-details/project-details-form.tsx
@@ -86,7 +86,11 @@ export const ProjectDetailsForm = ({
   return (
     <form onSubmit={handleSubmit((values) => onSubmit(values))}>
       {errorMessage && (
-        <FormError inDialog intro="Could not save" message={errorMessage} />
+        <FormError
+          inDialog
+          intro={translate(STRING.MESSAGE_COULD_NOT_SAVE)}
+          message={errorMessage}
+        />
       )}
       <FormSection>
         <FormRow>

--- a/ui/src/pages/project-details/project-details-form.tsx
+++ b/ui/src/pages/project-details/project-details-form.tsx
@@ -27,19 +27,23 @@ interface ProjectFormValues {
 
 const config: FormConfig = {
   name: {
-    label: 'Name',
+    label: translate(STRING.FIELD_LABEL_NAME),
     rules: {
       required: true,
     },
   },
   description: {
-    label: 'Description',
+    label: translate(STRING.FIELD_LABEL_DESCRIPTION),
   },
   image: {
-    label: 'Image',
-    description: `The image must smaller than ${bytesToMB(
-      IMAGE_MAX_SIZE
-    )} MB. Valid formats are PNG, GIF and JPEG.`,
+    label: translate(STRING.FIELD_LABEL_IMAGE),
+    description: [
+      translate(STRING.MESSAGE_IMAGE_SIZE, {
+        value: bytesToMB(IMAGE_MAX_SIZE),
+        unit: 'MB',
+      }),
+      translate(STRING.MESSAGE_IMAGE_FORMAT),
+    ].join('\n'),
     rules: {
       validate: (file: File) => {
         if (file) {

--- a/ui/src/pages/project-details/project-image-upload/project-image-upload.tsx
+++ b/ui/src/pages/project-details/project-image-upload/project-image-upload.tsx
@@ -2,6 +2,7 @@ import { Project } from 'data-services/models/project'
 import { Button } from 'design-system/components/button/button'
 import { FileInput } from 'design-system/components/file-input/file-input'
 import { FileInputAccept } from 'design-system/components/file-input/types'
+import { STRING, translate } from 'utils/language'
 import styles from './project-image-upload.module.scss'
 
 export const ProjectImageUpload = ({
@@ -29,7 +30,9 @@ export const ProjectImageUpload = ({
         {imageUrl ? (
           <img src={imageUrl} />
         ) : (
-          <span className={styles.info}>No image</span>
+          <span className={styles.info}>
+            {translate(STRING.MESSAGE_NO_IMAGE)}
+          </span>
         )}
       </div>
       <FileInput
@@ -38,7 +41,11 @@ export const ProjectImageUpload = ({
         renderInput={(props) => (
           <Button
             {...props}
-            label={imageUrl ? 'Change image' : 'Choose image'}
+            label={
+              imageUrl
+                ? translate(STRING.CHANGE_IMAGE)
+                : translate(STRING.CHOOSE_IMAGE)
+            }
           />
         )}
         withClear

--- a/ui/src/pages/projects/project-gallery.tsx
+++ b/ui/src/pages/projects/project-gallery.tsx
@@ -7,6 +7,7 @@ import { EditProjectDialog } from 'pages/project-details/edit-project-dialog'
 import { useMemo } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { APP_ROUTES } from 'utils/constants'
+import { STRING, translate } from 'utils/language'
 import styles from './projects.module.scss'
 
 export const ProjectGallery = ({
@@ -53,7 +54,12 @@ export const ProjectGallery = ({
             <div className={styles.projectActions}>
               {project?.canDelete && <DeleteProjectDialog id={item.id} />}
               {project?.canUpdate && <EditProjectDialog id={item.id} />}
-              <Button label="View project" onClick={() => navigate(item.to)} />
+              <Button
+                label={translate(STRING.ENTITY_VIEW, {
+                  type: translate(STRING.ENTITY_TYPE_PROJECT),
+                })}
+                onClick={() => navigate(item.to)}
+              />
             </div>
           </Card>
         )

--- a/ui/src/utils/language.ts
+++ b/ui/src/utils/language.ts
@@ -171,6 +171,19 @@ const ENGLISH_STRINGS: { [key in STRING]: string } = {
 }
 
 // When we have more translations available, this function could return a value based on current language settings.
-export const translate = (key: STRING): string => {
-  return ENGLISH_STRINGS[key]
+export const translate = (
+  key: STRING,
+  values?: { [key: string]: string | number }
+): string => {
+  let string = ENGLISH_STRINGS[key]
+
+  if (!values) {
+    return string
+  }
+
+  Object.entries(values).forEach(([key, value]) => {
+    string = string.replace(`{{${key}}}`, `${value}`)
+  })
+
+  return string
 }

--- a/ui/src/utils/language.ts
+++ b/ui/src/utils/language.ts
@@ -10,12 +10,16 @@ export enum STRING {
   DELETED,
   EDIT,
   NEXT,
+  LOGIN,
+  LOGOUT,
   REFRESH,
   RESET,
   RETRY,
   SAVE,
   SAVED,
   SEARCH_MAP,
+  SIGN_UP,
+  VIEW_PUBLIC_PROJECTS,
 
   /* ENTITY */
   ENTITY_CREATE,
@@ -37,6 +41,7 @@ export enum STRING {
   FIELD_LABEL_DESCRIPTION,
   FIELD_LABEL_DETECTIONS,
   FIELD_LABEL_DURATION,
+  FIELD_LABEL_EMAIL,
   FIELD_LABEL_GENERAL,
   FIELD_LABEL_ID,
   FIELD_LABEL_IMAGE,
@@ -46,6 +51,7 @@ export enum STRING {
   FIELD_LABEL_MOST_RECENT,
   FIELD_LABEL_NAME,
   FIELD_LABEL_OCCURRENCES,
+  FIELD_LABEL_PASSWORD,
   FIELD_LABEL_PATH,
   FIELD_LABEL_PROJECT,
   FIELD_LABEL_SESSION,
@@ -64,12 +70,18 @@ export enum STRING {
   MESSAGE_CAPTURE_LIMIT,
   MESSAGE_CAPTURE_TOO_MANY,
   MESSAGE_CAPTURE_UPLOAD_HIDDEN,
+  MESSAGE_CHANGE_PASSWORD,
+  MESSAGE_COULD_NOT_SAVE,
   MESSAGE_DELETE_CONFIRM,
+  MESSAGE_HAS_ACCOUNT,
   MESSAGE_IMAGE_FORMAT,
   MESSAGE_IMAGE_SIZE,
   MESSAGE_IMAGE_TOO_BIG,
+  MESSAGE_NO_ACCOUNT_YET,
   MESSAGE_NO_IMAGE,
   MESSAGE_NO_RESULTS,
+  MESSAGE_PASSWORD_FORMAT,
+  MESSAGE_SIGNED_UP,
   MESSAGE_VALUE_INVALID,
   MESSAGE_VALUE_MISSING,
 
@@ -96,11 +108,13 @@ export enum STRING {
   LAST_UPDATED,
   LOADING_DATA,
   NOT_CONNECTED,
+  OR,
   PENDING,
   RUNNING,
   SELECT_COLUMNS,
   UNKNOWN,
   UPDATING_DATA,
+  USER_INFO,
 }
 
 const ENGLISH_STRINGS: { [key in STRING]: string } = {
@@ -114,6 +128,8 @@ const ENGLISH_STRINGS: { [key in STRING]: string } = {
   [STRING.CLEAR]: 'Clear',
   [STRING.CURRENT_LOCATION]: 'Use current location',
   [STRING.EDIT]: 'Edit',
+  [STRING.LOGIN]: 'Login',
+  [STRING.LOGOUT]: 'Logout',
   [STRING.NEXT]: 'Next',
   [STRING.REFRESH]: 'Refresh',
   [STRING.RESET]: 'Reset',
@@ -121,6 +137,8 @@ const ENGLISH_STRINGS: { [key in STRING]: string } = {
   [STRING.SAVE]: 'Save',
   [STRING.SAVED]: 'Saved',
   [STRING.SEARCH_MAP]: 'Search on the map',
+  [STRING.SIGN_UP]: 'Sign up',
+  [STRING.VIEW_PUBLIC_PROJECTS]: 'View public projects',
 
   /* FIELD_LABEL */
   [STRING.FIELD_LABEL_AVG_TEMP]: 'Avg temp',
@@ -131,6 +149,7 @@ const ENGLISH_STRINGS: { [key in STRING]: string } = {
   [STRING.FIELD_LABEL_DESCRIPTION]: 'Description',
   [STRING.FIELD_LABEL_DETECTIONS]: 'Detection(s)',
   [STRING.FIELD_LABEL_DURATION]: 'Duration',
+  [STRING.FIELD_LABEL_EMAIL]: 'Email',
   [STRING.FIELD_LABEL_GENERAL]: 'General',
   [STRING.FIELD_LABEL_ID]: 'ID',
   [STRING.FIELD_LABEL_IMAGE]: 'Image',
@@ -140,6 +159,7 @@ const ENGLISH_STRINGS: { [key in STRING]: string } = {
   [STRING.FIELD_LABEL_MOST_RECENT]: 'Most recent',
   [STRING.FIELD_LABEL_NAME]: 'Name',
   [STRING.FIELD_LABEL_OCCURRENCES]: 'Occurrences',
+  [STRING.FIELD_LABEL_PASSWORD]: 'Password',
   [STRING.FIELD_LABEL_PATH]: 'Path',
   [STRING.FIELD_LABEL_PROJECT]: 'Project',
   [STRING.FIELD_LABEL_SESSION]: 'Session',
@@ -158,7 +178,7 @@ const ENGLISH_STRINGS: { [key in STRING]: string } = {
   [STRING.ENTITY_DELETE]: 'Delete {{type}}',
   [STRING.ENTITY_DETAILS]: '{{type}} details',
   [STRING.ENTITY_EDIT]: 'Edit {{type}}',
-  [STRING.ENTITY_TYPE_CAPTURE]: 'capture',
+  [STRING.ENTITY_TYPE_CAPTURE]: 'dapture',
   [STRING.ENTITY_TYPE_DEPLOYMENT]: 'deployment',
   [STRING.ENTITY_TYPE_IDENTIFICATION]: 'identification',
   [STRING.ENTITY_TYPE_PROJECT]: 'project',
@@ -171,16 +191,26 @@ const ENGLISH_STRINGS: { [key in STRING]: string } = {
     'A maximum of {{numCaptures}} captures can be uploaded.',
   [STRING.MESSAGE_CAPTURE_TOO_MANY]:
     'To upload more than {{numCaptures}} images you must configure a data source.',
+
   [STRING.MESSAGE_CAPTURE_UPLOAD_HIDDEN]:
     'Deployment must be saved before uploading captures.',
+  [STRING.MESSAGE_CHANGE_PASSWORD]:
+    'Contact an administrator to change your email or password.',
+  [STRING.MESSAGE_COULD_NOT_SAVE]: 'Could not save',
   [STRING.MESSAGE_DELETE_CONFIRM]:
     'Are you sure you want to delete this {{type}}?',
+  [STRING.MESSAGE_HAS_ACCOUNT]: 'Already have an account?',
   [STRING.MESSAGE_IMAGE_FORMAT]: 'Valid formats are PNG, GIF and JPEG.',
   [STRING.MESSAGE_IMAGE_SIZE]:
     'The image must smaller than {{value}} {{unit}}.',
   [STRING.MESSAGE_IMAGE_TOO_BIG]: 'Please provide a smaller image',
+  [STRING.MESSAGE_NO_ACCOUNT_YET]: 'No account yet?',
+
   [STRING.MESSAGE_NO_IMAGE]: 'No image',
   [STRING.MESSAGE_NO_RESULTS]: 'No results to show',
+  [STRING.MESSAGE_PASSWORD_FORMAT]:
+    'The password must contain at least 8 characters and cannot be entirely numeric.',
+  [STRING.MESSAGE_SIGNED_UP]: 'Signed up successfully!',
   [STRING.MESSAGE_VALUE_INVALID]: 'Please provide a valid value',
   [STRING.MESSAGE_VALUE_MISSING]: 'Please provide a value',
 
@@ -207,11 +237,13 @@ const ENGLISH_STRINGS: { [key in STRING]: string } = {
   [STRING.LAST_UPDATED]: 'Last updated',
   [STRING.LOADING_DATA]: 'Loading data',
   [STRING.NOT_CONNECTED]: 'Not connected',
+  [STRING.OR]: 'Or',
   [STRING.PENDING]: 'Pending',
   [STRING.RUNNING]: 'Running',
   [STRING.SELECT_COLUMNS]: 'Select columns',
   [STRING.UNKNOWN]: 'Unknown',
   [STRING.UPDATING_DATA]: 'Updating data',
+  [STRING.USER_INFO]: 'User info',
 }
 
 // When we have more translations available, this function could return a value based on current language settings.

--- a/ui/src/utils/language.ts
+++ b/ui/src/utils/language.ts
@@ -7,6 +7,7 @@ export enum STRING {
   NEXT,
   REFRESH,
   RESET,
+  RETRY,
   SAVE,
   SAVED,
   SEARCH_MAP,
@@ -49,6 +50,12 @@ export enum STRING {
   FIELD_LABEL_UPLOADED_CAPTURES,
 
   /* MESSAGE */
+  MESSAGE_CAPTURE_FILENAME,
+  MESSAGE_CAPTURE_LIMIT,
+  MESSAGE_CAPTURE_TOO_MANY,
+  MESSAGE_CAPTURE_UPLOAD_HIDDEN,
+  MESSAGE_IMAGE_FORMAT,
+  MESSAGE_IMAGE_SIZE,
   MESSAGE_IMAGE_TOO_BIG,
   MESSAGE_VALUE_INVALID,
   MESSAGE_VALUE_MISSING,
@@ -70,6 +77,7 @@ export enum STRING {
   TAB_ITEM_TABLE,
 
   /* OTHER */
+  CAPTURE,
   CLOSE,
   CONNECTED,
   CONNECTING,
@@ -93,6 +101,7 @@ const ENGLISH_STRINGS: { [key in STRING]: string } = {
   [STRING.NEXT]: 'Next',
   [STRING.REFRESH]: 'Refresh',
   [STRING.RESET]: 'Reset',
+  [STRING.RETRY]: 'Retry',
   [STRING.SAVE]: 'Save',
   [STRING.SAVED]: 'Saved',
   [STRING.SEARCH_MAP]: 'Search on the map',
@@ -135,6 +144,17 @@ const ENGLISH_STRINGS: { [key in STRING]: string } = {
   [STRING.FIELD_LABEL_UPLOADED_CAPTURES]: 'Manually uploaded captures',
 
   /* MESSAGE */
+  [STRING.MESSAGE_CAPTURE_FILENAME]:
+    'Image filename must contain a timestamp in the format YYYYMMDDHHMMSS (e.g. 20210101120000-snapshot.jpg).',
+  [STRING.MESSAGE_CAPTURE_LIMIT]:
+    'A maximum of {{numCaptures}} captures can be uploaded.',
+  [STRING.MESSAGE_CAPTURE_TOO_MANY]:
+    'To upload more than {{numCaptures}} images you must configure a data source.',
+  [STRING.MESSAGE_CAPTURE_UPLOAD_HIDDEN]:
+    'Deployment must be saved before uploading captures.',
+  [STRING.MESSAGE_IMAGE_FORMAT]: 'Valid formats are PNG, GIF and JPEG.',
+  [STRING.MESSAGE_IMAGE_SIZE]:
+    'The image must smaller than {{value}} {{unit}}.',
   [STRING.MESSAGE_IMAGE_TOO_BIG]: 'Please provide a smaller image',
   [STRING.MESSAGE_VALUE_INVALID]: 'Please provide a valid value',
   [STRING.MESSAGE_VALUE_MISSING]: 'Please provide a value',
@@ -156,6 +176,7 @@ const ENGLISH_STRINGS: { [key in STRING]: string } = {
   [STRING.TAB_ITEM_TABLE]: 'Table',
 
   /* OTHER */
+  [STRING.CAPTURE]: 'Capture',
   [STRING.CLOSE]: 'Close',
   [STRING.CONNECTED]: 'Connected',
   [STRING.CONNECTING]: 'Connecting',

--- a/ui/src/utils/language.ts
+++ b/ui/src/utils/language.ts
@@ -2,7 +2,12 @@ export enum STRING {
   /* BUTTON */
   BACK,
   CANCEL,
+  CHANGE_IMAGE,
+  CHOOSE_IMAGE,
+  CLEAR,
   CURRENT_LOCATION,
+  DELETE,
+  DELETED,
   EDIT,
   NEXT,
   REFRESH,
@@ -12,12 +17,16 @@ export enum STRING {
   SAVED,
   SEARCH_MAP,
 
-  /* DIALOG */
-  DIALOG_DEPLOYMENT_DETAILS,
-  DIALOG_EDIT_DEPLOYMENT,
-  DIALOG_EDIT_PROJECT,
-  DIALOG_NEW_DEPLOYMENT,
-  DIALOG_NEW_PROJECT,
+  /* ENTITY */
+  ENTITY_CREATE,
+  ENTITY_DELETE,
+  ENTITY_DETAILS,
+  ENTITY_EDIT,
+  ENTITY_TYPE_CAPTURE,
+  ENTITY_TYPE_DEPLOYMENT,
+  ENTITY_TYPE_IDENTIFICATION,
+  ENTITY_TYPE_PROJECT,
+  ENTITY_VIEW,
 
   /* FIELD_LABEL */
   FIELD_LABEL_AVG_TEMP,
@@ -30,6 +39,7 @@ export enum STRING {
   FIELD_LABEL_DURATION,
   FIELD_LABEL_GENERAL,
   FIELD_LABEL_ID,
+  FIELD_LABEL_IMAGE,
   FIELD_LABEL_LATITUDE,
   FIELD_LABEL_LOCATION,
   FIELD_LABEL_LONGITUDE,
@@ -54,12 +64,14 @@ export enum STRING {
   MESSAGE_CAPTURE_LIMIT,
   MESSAGE_CAPTURE_TOO_MANY,
   MESSAGE_CAPTURE_UPLOAD_HIDDEN,
+  MESSAGE_DELETE_CONFIRM,
   MESSAGE_IMAGE_FORMAT,
   MESSAGE_IMAGE_SIZE,
   MESSAGE_IMAGE_TOO_BIG,
+  MESSAGE_NO_IMAGE,
+  MESSAGE_NO_RESULTS,
   MESSAGE_VALUE_INVALID,
   MESSAGE_VALUE_MISSING,
-  MESSAGE_NO_RESULTS,
 
   /* NAV_ITEM */
   NAV_ITEM_DEPLOYMENTS,
@@ -77,7 +89,6 @@ export enum STRING {
   TAB_ITEM_TABLE,
 
   /* OTHER */
-  CAPTURE,
   CLOSE,
   CONNECTED,
   CONNECTING,
@@ -95,7 +106,12 @@ export enum STRING {
 const ENGLISH_STRINGS: { [key in STRING]: string } = {
   /* BUTTON */
   [STRING.BACK]: 'Back',
+  [STRING.DELETE]: 'Delete',
+  [STRING.DELETED]: 'Deleted',
   [STRING.CANCEL]: 'Cancel',
+  [STRING.CHANGE_IMAGE]: 'Change image',
+  [STRING.CHOOSE_IMAGE]: 'Choose image',
+  [STRING.CLEAR]: 'Clear',
   [STRING.CURRENT_LOCATION]: 'Use current location',
   [STRING.EDIT]: 'Edit',
   [STRING.NEXT]: 'Next',
@@ -105,13 +121,6 @@ const ENGLISH_STRINGS: { [key in STRING]: string } = {
   [STRING.SAVE]: 'Save',
   [STRING.SAVED]: 'Saved',
   [STRING.SEARCH_MAP]: 'Search on the map',
-
-  /* DIALOG */
-  [STRING.DIALOG_DEPLOYMENT_DETAILS]: 'Deployment details',
-  [STRING.DIALOG_EDIT_DEPLOYMENT]: 'Edit deployment',
-  [STRING.DIALOG_EDIT_PROJECT]: 'Edit project',
-  [STRING.DIALOG_NEW_DEPLOYMENT]: 'Register new deployment',
-  [STRING.DIALOG_NEW_PROJECT]: 'Register new project',
 
   /* FIELD_LABEL */
   [STRING.FIELD_LABEL_AVG_TEMP]: 'Avg temp',
@@ -124,6 +133,7 @@ const ENGLISH_STRINGS: { [key in STRING]: string } = {
   [STRING.FIELD_LABEL_DURATION]: 'Duration',
   [STRING.FIELD_LABEL_GENERAL]: 'General',
   [STRING.FIELD_LABEL_ID]: 'ID',
+  [STRING.FIELD_LABEL_IMAGE]: 'Image',
   [STRING.FIELD_LABEL_LATITUDE]: 'Latitude',
   [STRING.FIELD_LABEL_LOCATION]: 'Location',
   [STRING.FIELD_LABEL_LONGITUDE]: 'Longitude',
@@ -143,6 +153,17 @@ const ENGLISH_STRINGS: { [key in STRING]: string } = {
   [STRING.FIELD_LABEL_LAST_DATE]: 'Last date',
   [STRING.FIELD_LABEL_UPLOADED_CAPTURES]: 'Manually uploaded captures',
 
+  /* ENTITY */
+  [STRING.ENTITY_CREATE]: 'Register new {{type}}',
+  [STRING.ENTITY_DELETE]: 'Delete {{type}}',
+  [STRING.ENTITY_DETAILS]: '{{type}} details',
+  [STRING.ENTITY_EDIT]: 'Edit {{type}}',
+  [STRING.ENTITY_TYPE_CAPTURE]: 'capture',
+  [STRING.ENTITY_TYPE_DEPLOYMENT]: 'deployment',
+  [STRING.ENTITY_TYPE_IDENTIFICATION]: 'identification',
+  [STRING.ENTITY_TYPE_PROJECT]: 'project',
+  [STRING.ENTITY_VIEW]: 'View {{type}}',
+
   /* MESSAGE */
   [STRING.MESSAGE_CAPTURE_FILENAME]:
     'Image filename must contain a timestamp in the format YYYYMMDDHHMMSS (e.g. 20210101120000-snapshot.jpg).',
@@ -152,13 +173,16 @@ const ENGLISH_STRINGS: { [key in STRING]: string } = {
     'To upload more than {{numCaptures}} images you must configure a data source.',
   [STRING.MESSAGE_CAPTURE_UPLOAD_HIDDEN]:
     'Deployment must be saved before uploading captures.',
+  [STRING.MESSAGE_DELETE_CONFIRM]:
+    'Are you sure you want to delete this {{type}}?',
   [STRING.MESSAGE_IMAGE_FORMAT]: 'Valid formats are PNG, GIF and JPEG.',
   [STRING.MESSAGE_IMAGE_SIZE]:
     'The image must smaller than {{value}} {{unit}}.',
   [STRING.MESSAGE_IMAGE_TOO_BIG]: 'Please provide a smaller image',
+  [STRING.MESSAGE_NO_IMAGE]: 'No image',
+  [STRING.MESSAGE_NO_RESULTS]: 'No results to show',
   [STRING.MESSAGE_VALUE_INVALID]: 'Please provide a valid value',
   [STRING.MESSAGE_VALUE_MISSING]: 'Please provide a value',
-  [STRING.MESSAGE_NO_RESULTS]: 'No results to show',
 
   /* NAV_ITEM */
   [STRING.NAV_ITEM_DEPLOYMENTS]: 'Deployments',
@@ -176,7 +200,6 @@ const ENGLISH_STRINGS: { [key in STRING]: string } = {
   [STRING.TAB_ITEM_TABLE]: 'Table',
 
   /* OTHER */
-  [STRING.CAPTURE]: 'Capture',
   [STRING.CLOSE]: 'Close',
   [STRING.CONNECTED]: 'Connected',
   [STRING.CONNECTING]: 'Connecting',

--- a/ui/src/utils/language.ts
+++ b/ui/src/utils/language.ts
@@ -1,5 +1,7 @@
 export enum STRING {
   /* BUTTON */
+  AGREE,
+  AGREED,
   BACK,
   CANCEL,
   CHANGE_IMAGE,
@@ -19,6 +21,8 @@ export enum STRING {
   SAVED,
   SEARCH_MAP,
   SIGN_UP,
+  SUBMIT,
+  SUGGEST_ID,
   VIEW_PUBLIC_PROJECTS,
 
   /* ENTITY */
@@ -35,6 +39,7 @@ export enum STRING {
   /* FIELD_LABEL */
   FIELD_LABEL_AVG_TEMP,
   FIELD_LABEL_CAPTURES,
+  FIELD_LABEL_COMMENT,
   FIELD_LABEL_CONNECTION_STATUS,
   FIELD_LABEL_DATE,
   FIELD_LABEL_DEPLOYMENT,
@@ -59,6 +64,7 @@ export enum STRING {
   FIELD_LABEL_SOURCE_IMAGES,
   FIELD_LABEL_SPECIES,
   FIELD_LABEL_STATUS,
+  FIELD_LABEL_TAXON,
   FIELD_LABEL_TIME,
   FIELD_LABEL_TRAINING_IMAGES,
   FIELD_LABEL_FIRST_DATE,
@@ -105,8 +111,12 @@ export enum STRING {
   CONNECTED,
   CONNECTING,
   DONE,
+  ID_APPLIED,
   LAST_UPDATED,
   LOADING_DATA,
+  MACHINE_PREDICTION_SCORE,
+  MACHINE_SUGGESTION,
+  NEW_ID,
   NOT_CONNECTED,
   OR,
   PENDING,
@@ -115,10 +125,13 @@ export enum STRING {
   UNKNOWN,
   UPDATING_DATA,
   USER_INFO,
+  VERIFIED_BY,
 }
 
 const ENGLISH_STRINGS: { [key in STRING]: string } = {
   /* BUTTON */
+  [STRING.AGREE]: 'Agree',
+  [STRING.AGREED]: 'Agreed',
   [STRING.BACK]: 'Back',
   [STRING.DELETE]: 'Delete',
   [STRING.DELETED]: 'Deleted',
@@ -138,11 +151,14 @@ const ENGLISH_STRINGS: { [key in STRING]: string } = {
   [STRING.SAVED]: 'Saved',
   [STRING.SEARCH_MAP]: 'Search on the map',
   [STRING.SIGN_UP]: 'Sign up',
+  [STRING.SUBMIT]: 'Submit',
+  [STRING.SUGGEST_ID]: 'Suggest ID',
   [STRING.VIEW_PUBLIC_PROJECTS]: 'View public projects',
 
   /* FIELD_LABEL */
   [STRING.FIELD_LABEL_AVG_TEMP]: 'Avg temp',
   [STRING.FIELD_LABEL_CAPTURES]: 'Captures',
+  [STRING.FIELD_LABEL_COMMENT]: 'Comment',
   [STRING.FIELD_LABEL_CONNECTION_STATUS]: 'Connection status',
   [STRING.FIELD_LABEL_DATE]: 'Date',
   [STRING.FIELD_LABEL_DEPLOYMENT]: 'Deployment',
@@ -167,6 +183,7 @@ const ENGLISH_STRINGS: { [key in STRING]: string } = {
   [STRING.FIELD_LABEL_SOURCE_IMAGES]: 'Source images',
   [STRING.FIELD_LABEL_SPECIES]: 'Species',
   [STRING.FIELD_LABEL_STATUS]: 'Status',
+  [STRING.FIELD_LABEL_TAXON]: 'Taxon',
   [STRING.FIELD_LABEL_TIME]: 'Time',
   [STRING.FIELD_LABEL_TRAINING_IMAGES]: 'Training images',
   [STRING.FIELD_LABEL_FIRST_DATE]: 'First date',
@@ -234,8 +251,12 @@ const ENGLISH_STRINGS: { [key in STRING]: string } = {
   [STRING.CONNECTED]: 'Connected',
   [STRING.CONNECTING]: 'Connecting',
   [STRING.DONE]: 'Done',
+  [STRING.ID_APPLIED]: 'ID applied',
   [STRING.LAST_UPDATED]: 'Last updated',
   [STRING.LOADING_DATA]: 'Loading data',
+  [STRING.MACHINE_PREDICTION_SCORE]: 'Machine prediction\nscore {{score}}',
+  [STRING.MACHINE_SUGGESTION]: 'Machine suggestion',
+  [STRING.NEW_ID]: 'New ID',
   [STRING.NOT_CONNECTED]: 'Not connected',
   [STRING.OR]: 'Or',
   [STRING.PENDING]: 'Pending',
@@ -244,6 +265,7 @@ const ENGLISH_STRINGS: { [key in STRING]: string } = {
   [STRING.UNKNOWN]: 'Unknown',
   [STRING.UPDATING_DATA]: 'Updating data',
   [STRING.USER_INFO]: 'User info',
+  [STRING.VERIFIED_BY]: 'Verified by\n{{name}}',
 }
 
 // When we have more translations available, this function could return a value based on current language settings.


### PR DESCRIPTION
Add translations for:
- Example captures
- Projects
- Sign up and login
- User info dialog
- Identifications

Also cleaning up translations a bit in general. For example, we introduce "entity strings", which makes it easier to avoid repeated copy. Also we setup a simple way to handle dynamic strings inspired by i18n framework.