### PR TITLE
Fix sorting in API

### DIFF
--- a/ami/main/api/serializers.py
+++ b/ami/main/api/serializers.py
@@ -407,6 +407,8 @@ class TaxonListSerializer(DefaultSerializer):
             "occurrences",
             "occurrence_images",
             "last_detected",
+            "created_at",
+            "updated_at",
         ]
 
     def get_occurrences(self, obj):

--- a/ami/main/api/views.py
+++ b/ami/main/api/views.py
@@ -84,11 +84,11 @@ class DefaultViewSetMixin:
     permission_classes = [permissions.AllowAny]
 
 
-class DefaultViewSet(viewsets.ModelViewSet, DefaultViewSetMixin):
+class DefaultViewSet(DefaultViewSetMixin, viewsets.ModelViewSet):
     pass
 
 
-class DefaultReadOnlyViewSet(viewsets.ReadOnlyModelViewSet, DefaultViewSetMixin):
+class DefaultReadOnlyViewSet(DefaultViewSetMixin, viewsets.ReadOnlyModelViewSet):
     pass
 
 

--- a/ami/main/api/views.py
+++ b/ami/main/api/views.py
@@ -120,13 +120,23 @@ class DeploymentViewSet(DefaultViewSet):
         events_count=models.Count("events", distinct=True),
         occurrences_count=models.Count("occurrences", distinct=True),
         taxa_count=models.Count("occurrences__determination", distinct=True),
+        captures_count=models.Count("events__captures", distinct=True),
         # The first and last date should come from the captures,
         # but it may be much slower to query.
         first_date=models.Min("events__start__date"),
         last_date=models.Max("events__end__date"),
     ).select_related("project")
     filterset_fields = ["project"]
-    ordering_fields = ["created_at", "updated_at", "occurrences_count", "events_count"]
+    ordering_fields = [
+        "created_at",
+        "updated_at",
+        "captures_count",
+        "events_count",
+        "occurrences_count",
+        "taxa_count",
+        "first_date",
+        "last_date",
+    ]
 
     def get_serializer_class(self):
         """
@@ -162,6 +172,7 @@ class EventViewSet(DefaultViewSet):
         "captures_count",
         "detections_count",
         "occurrences_count",
+        "taxa_count",
         "duration",
     ]
 


### PR DESCRIPTION
Sorting was disabled in the backend due to the order of inheritance in our base view class.