### PR TITLE
Update sorting

### DIFF
--- a/ui/src/pages/jobs/jobs-columns.tsx
+++ b/ui/src/pages/jobs/jobs-columns.tsx
@@ -26,13 +26,9 @@ export const columns: (projectId: string) => TableColumn<Job>[] = (
     ),
   },
   {
-    id: 'project',
-    name: translate(STRING.FIELD_LABEL_PROJECT),
-    renderCell: (item: Job) => <BasicTableCell value={item.project} />,
-  },
-  {
     id: 'started-at',
     name: 'Started at',
+    sortField: 'started_at',
     renderCell: (item: Job) => <BasicTableCell value={item.startedAt} />,
   },
   {
@@ -43,6 +39,7 @@ export const columns: (projectId: string) => TableColumn<Job>[] = (
   {
     id: 'status',
     name: translate(STRING.FIELD_LABEL_STATUS),
+    sortField: 'status',
     renderCell: (item: Job) => {
       const status = (() => {
         switch (item.status) {

--- a/ui/src/pages/jobs/jobs.tsx
+++ b/ui/src/pages/jobs/jobs.tsx
@@ -4,8 +4,10 @@ import { useJobs } from 'data-services/hooks/jobs/useJobs'
 import * as Dialog from 'design-system/components/dialog/dialog'
 import { PaginationBar } from 'design-system/components/pagination/pagination-bar'
 import { Table } from 'design-system/components/table/table/table'
+import { TableSortSettings } from 'design-system/components/table/types'
 import { Error } from 'pages/error/error'
 import { JobDetails } from 'pages/job-details/job-details'
+import { useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { APP_ROUTES } from 'utils/constants'
 import { getAppRoute } from 'utils/getAppRoute'
@@ -16,10 +18,12 @@ import styles from './jobs.module.scss'
 
 export const Jobs = () => {
   const { projectId, id } = useParams()
+  const [sort, setSort] = useState<TableSortSettings>()
   const { pagination, setPrevPage, setNextPage } = usePagination()
   const { jobs, total, isLoading, isFetching, error } = useJobs({
     projectId,
     pagination,
+    sort,
   })
 
   if (!isLoading && error) {
@@ -37,6 +41,9 @@ export const Jobs = () => {
         items={jobs}
         isLoading={isLoading}
         columns={columns(projectId as string)}
+        sortable
+        sortSettings={sort}
+        onSortSettingsChange={setSort}
       />
       {!isLoading && id ? <JobDetailsDialog id={id} /> : null}
       {jobs?.length ? (

--- a/ui/src/pages/occurrences/occurrence-columns.tsx
+++ b/ui/src/pages/occurrences/occurrence-columns.tsx
@@ -27,6 +27,7 @@ export const columns: (projectId: string) => TableColumn<Occurrence>[] = (
   {
     id: 'snapshots',
     name: translate(STRING.FIELD_LABEL_MOST_RECENT),
+    sortField: 'updated_at',
     styles: {
       padding: '16px 32px 16px 50px',
     },

--- a/ui/src/pages/sessions/session-columns.tsx
+++ b/ui/src/pages/sessions/session-columns.tsx
@@ -18,7 +18,7 @@ export const columns: (projectId: string) => TableColumn<Session>[] = (
   {
     id: 'snapshots',
     name: translate(STRING.FIELD_LABEL_MOST_RECENT),
-    sortField: 'start',
+    sortField: 'updated_at',
     styles: {
       padding: '16px 32px 16px 50px',
     },
@@ -35,6 +35,7 @@ export const columns: (projectId: string) => TableColumn<Session>[] = (
   },
   {
     id: 'session',
+    sortField: 'start',
     name: translate(STRING.FIELD_LABEL_SESSION),
     renderCell: (item: Session) => (
       <Link to={APP_ROUTES.SESSION_DETAILS({ projectId, sessionId: item.id })}>

--- a/ui/src/pages/sessions/session-columns.tsx
+++ b/ui/src/pages/sessions/session-columns.tsx
@@ -18,6 +18,7 @@ export const columns: (projectId: string) => TableColumn<Session>[] = (
   {
     id: 'snapshots',
     name: translate(STRING.FIELD_LABEL_MOST_RECENT),
+    sortField: 'start',
     styles: {
       padding: '16px 32px 16px 50px',
     },
@@ -60,7 +61,6 @@ export const columns: (projectId: string) => TableColumn<Session>[] = (
   },
   {
     id: 'date',
-    sortField: 'start',
     name: translate(STRING.FIELD_LABEL_DATE),
     renderCell: (item: Session) => (
       <BasicTableCell value={item.datespanLabel} />
@@ -75,7 +75,6 @@ export const columns: (projectId: string) => TableColumn<Session>[] = (
   },
   {
     id: 'duration',
-    sortField: 'duration',
     name: translate(STRING.FIELD_LABEL_DURATION),
     renderCell: (item: Session) => (
       <BasicTableCell value={item.durationLabel} />
@@ -92,6 +91,7 @@ export const columns: (projectId: string) => TableColumn<Session>[] = (
   },
   {
     id: 'detections',
+    sortField: 'detections_count',
     name: translate(STRING.FIELD_LABEL_DETECTIONS),
     styles: {
       textAlign: TextAlign.Right,
@@ -120,6 +120,7 @@ export const columns: (projectId: string) => TableColumn<Session>[] = (
   },
   {
     id: 'species',
+    sortField: 'taxa_count',
     name: translate(STRING.FIELD_LABEL_SPECIES),
     styles: {
       textAlign: TextAlign.Right,

--- a/ui/src/pages/species/species-columns.tsx
+++ b/ui/src/pages/species/species-columns.tsx
@@ -50,6 +50,7 @@ export const columns: (projectId: string) => TableColumn<Species>[] = (
   },
   {
     id: 'detections',
+    sortField: 'detections_count',
     name: translate(STRING.FIELD_LABEL_DETECTIONS),
     styles: {
       textAlign: TextAlign.Right,
@@ -60,6 +61,7 @@ export const columns: (projectId: string) => TableColumn<Species>[] = (
   },
   {
     id: 'occurrences',
+    sortField: 'occurrences_count',
     name: translate(STRING.FIELD_LABEL_OCCURRENCES),
     styles: {
       textAlign: TextAlign.Right,


### PR DESCRIPTION
Checked API endpoints to see what sorting is currently available. Tried to match everything I could find to table columns. Here is an updated list of current sort settings available from web UI. Fixes https://github.com/RolnickLab/ami-platform/issues/290

### Page
- Column name (api_sort_field)

### Status
- Started at (started_at)
- Status (status)

### Deployments
Client side sorting available for all columns.

### Sessions
- Most recent (updated_at)
- Session (start)
- Captures (captures_count)
- Detections (detections_count)
- Occurrences (occurrences_count)
- Species (taxa_count)

### Occurrences
- Most recent (updated_at)

### Species
- Most recent (updated_at)
- Name (name)
- Detections (detections_count)
- Occurrences (occurrences_count)