### PR TITLE
Lazy load Plotly

### DIFF
--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -11,11 +11,13 @@ import { CollectionDetails } from 'pages/collection-details/collection-details'
 import { Deployments } from 'pages/deployments/deployments'
 import { Jobs } from 'pages/jobs/jobs'
 import { Occurrences } from 'pages/occurrences/occurrences'
+import Overview from 'pages/overview/overview'
 import { Projects } from 'pages/projects/projects'
+import SessionDetails from 'pages/session-details/session-details'
 import { Sessions } from 'pages/sessions/sessions'
 import { Species } from 'pages/species/species'
 import { UnderConstruction } from 'pages/under-construction/under-construction'
-import React, { Suspense, useContext, useEffect } from 'react'
+import { useContext, useEffect } from 'react'
 import { Navigate, Outlet, Route, Routes, useParams } from 'react-router-dom'
 import {
   BreadcrumbContext,
@@ -26,11 +28,6 @@ import { STRING, translate } from 'utils/language'
 import { usePageBreadcrumb } from 'utils/usePageBreadcrumb'
 import { UserContextProvider } from 'utils/user/userContext'
 import styles from './app.module.scss'
-
-const Overview = React.lazy(() => import('./pages/overview/overview'))
-const SessionDetails = React.lazy(
-  () => import('./pages/session-details/session-details')
-)
 
 const queryClient = new QueryClient()
 
@@ -61,25 +58,11 @@ export const App = () => {
               </Route>
               <Route path="projects" element={<ProjectsContainer />} />
               <Route path="projects/:projectId" element={<ProjectContainer />}>
-                <Route
-                  path=""
-                  element={
-                    <Suspense>
-                      <Overview />
-                    </Suspense>
-                  }
-                />
+                <Route path="" element={<Overview />} />
                 <Route path="jobs/:id?" element={<Jobs />} />
                 <Route path="deployments/:id?" element={<Deployments />} />
                 <Route path="sessions" element={<Sessions />} />
-                <Route
-                  path="sessions/:id"
-                  element={
-                    <Suspense>
-                      <SessionDetails />
-                    </Suspense>
-                  }
-                />
+                <Route path="sessions/:id" element={<SessionDetails />} />
                 <Route path="occurrences/:id?" element={<Occurrences />} />
                 <Route path="species/:id?" element={<Species />} />
                 <Route path="collections/:id" element={<CollectionDetails />} />

--- a/ui/src/design-system/components/plot/lazy-plot.tsx
+++ b/ui/src/design-system/components/plot/lazy-plot.tsx
@@ -1,0 +1,11 @@
+import React, { Suspense } from 'react'
+import { LoadingSpinner } from '../loading-spinner/loading-spinner'
+import { PlotProps } from './types'
+
+const _Plot = React.lazy(() => import('./plot'))
+
+export const Plot = (props: PlotProps) => (
+  <Suspense fallback={<LoadingSpinner />}>
+    <_Plot {...props} />
+  </Suspense>
+)

--- a/ui/src/design-system/components/plot/plot.tsx
+++ b/ui/src/design-system/components/plot/plot.tsx
@@ -1,5 +1,6 @@
 import _Plot from 'react-plotly.js'
 import styles from './plot.module.scss'
+import { PlotProps } from './types'
 
 const fontFamily = 'AzoSans, sans-serif'
 const borderColor = '#f0f0f0'
@@ -9,21 +10,7 @@ const titleColor = '#6f7172'
 const tooltipBgColor = '#ffffff'
 const tooltipBorderColor = '#222426'
 
-interface PlotProps {
-  title: string
-  orientation?: 'h' | 'v'
-  data: {
-    x: (string | number)[]
-    y: (string | number)[]
-    tickvals?: (string | number)[]
-    ticktext?: string[]
-  }
-  type?: 'bar' | 'scatter'
-  showRangeSlider?: boolean
-  categorical?: boolean
-}
-
-export const Plot = ({
+const Plot = ({
   title,
   data,
   orientation,
@@ -112,3 +99,5 @@ export const Plot = ({
     />
   </div>
 )
+
+export default Plot

--- a/ui/src/design-system/components/plot/types.ts
+++ b/ui/src/design-system/components/plot/types.ts
@@ -1,0 +1,13 @@
+export interface PlotProps {
+  title: string
+  orientation?: 'h' | 'v'
+  data: {
+    x: (string | number)[]
+    y: (string | number)[]
+    tickvals?: (string | number)[]
+    ticktext?: string[]
+  }
+  type?: 'bar' | 'scatter'
+  showRangeSlider?: boolean
+  categorical?: boolean
+}

--- a/ui/src/pages/overview/overview.tsx
+++ b/ui/src/pages/overview/overview.tsx
@@ -10,7 +10,7 @@ import { DeploymentsMap } from './deployments-map/deployments-map'
 import styles from './overview.module.scss'
 import { Summary } from './summary/summary'
 
-const Overview = () => {
+export const Overview = () => {
   const { project, isLoading, error } = useOutletContext<{
     project?: Project
     isLoading: boolean

--- a/ui/src/pages/overview/summary/summary.tsx
+++ b/ui/src/pages/overview/summary/summary.tsx
@@ -1,7 +1,7 @@
 import { Project } from 'data-services/models/project'
 import { Box } from 'design-system/components/box/box'
 import { PlotGrid } from 'design-system/components/plot-grid/plot-grid'
-import { Plot } from 'design-system/components/plot/plot'
+import { Plot } from 'design-system/components/plot/lazy-plot'
 
 export const Summary = ({ project }: { project: Project }) => (
   <PlotGrid>

--- a/ui/src/pages/session-details/session-details.tsx
+++ b/ui/src/pages/session-details/session-details.tsx
@@ -3,7 +3,7 @@ import { useSessionDetails } from 'data-services/hooks/sessions/useSessionDetail
 import { Box } from 'design-system/components/box/box'
 import { LoadingSpinner } from 'design-system/components/loading-spinner/loading-spinner'
 import { PlotGrid } from 'design-system/components/plot-grid/plot-grid'
-import { Plot } from 'design-system/components/plot/plot'
+import { Plot } from 'design-system/components/plot/lazy-plot'
 import { Error } from 'pages/error/error'
 import { useContext, useEffect } from 'react'
 import { useParams } from 'react-router-dom'
@@ -15,7 +15,7 @@ import { useActiveOccurrences } from './playback/useActiveOccurrences'
 import styles from './session-details.module.scss'
 import { SessionInfo } from './session-info/session-info'
 
-const SessionDetails = () => {
+export const SessionDetails = () => {
   const { id } = useParams()
   const { setDetailBreadcrumb } = useContext(BreadcrumbContext)
   const { activeOccurrences } = useActiveOccurrences()


### PR DESCRIPTION
Fixes https://github.com/RolnickLab/ami-platform/issues/239

In this PR, we lazy load the plot component. We do this to extract Plotly lib from main bundle. Since loading the main bundle is render blocking, this will let users interact with the app quicker.

Chunks before:
<img width="472" alt="Screenshot 2023-11-20 at 09 41 44" src="https://github.com/RolnickLab/ami-platform/assets/11680517/3e95b91b-4df9-4d22-b930-f7976adf1704">

Chunks after (notice that plot chunk is way larger than rest of app):
<img width="467" alt="Screenshot 2023-11-20 at 09 38 07" src="https://github.com/RolnickLab/ami-platform/assets/11680517/bf1b640b-cc67-4195-beb8-5400f62555cc">

In UI, we will show loading spinners instead of plots while the plot chunk is loading (this will only happen first time the user visits a page where plots are present).
<img width="1641" alt="Screenshot 2023-11-20 at 09 42 51" src="https://github.com/RolnickLab/ami-platform/assets/11680517/ad104a7e-90a5-4b44-a9a2-a1c563d47c64">
