### PR TITLE
Setup error boundaries

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -28,6 +28,7 @@
     "plotly.js": "^2.20.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-error-boundary": "^4.0.11",
     "react-hook-form": "^7.43.9",
     "react-leaflet": "^4.2.1",
     "react-plotly.js": "^2.6.0",

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -1,6 +1,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import classNames from 'classnames'
+import { ErrorBoundary } from 'components/error-boundary/error-boundary'
 import { Header } from 'components/header/header'
 import { Menu } from 'components/menu/menu'
 import { useProjectDetails } from 'data-services/hooks/projects/useProjectDetails'
@@ -79,7 +80,9 @@ export const App = () => {
 const AuthContainer = () => (
   <main className={classNames(styles.main, styles.fullscreen)}>
     <Auth>
-      <Outlet />
+      <ErrorBoundary>
+        <Outlet />
+      </ErrorBoundary>
     </Auth>
   </main>
 )
@@ -93,7 +96,9 @@ const ProjectsContainer = () => {
   return (
     <main className={styles.main}>
       <div className={styles.content}>
-        <Projects />
+        <ErrorBoundary>
+          <Projects />
+        </ErrorBoundary>
       </div>
     </main>
   )
@@ -141,7 +146,9 @@ const ProjectContainer = () => {
       <Menu />
       <main className={styles.main}>
         <div className={styles.content}>
-          <Outlet context={projectDetails} />
+          <ErrorBoundary>
+            <Outlet context={projectDetails} />
+          </ErrorBoundary>
         </div>
       </main>
     </>

--- a/ui/src/components/error-boundary/error-boundary.module.scss
+++ b/ui/src/components/error-boundary/error-boundary.module.scss
@@ -1,0 +1,21 @@
+@import 'src/design-system/variables/colors.scss';
+@import 'src/design-system/variables/typography.scss';
+
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  width: 100%;
+  height: 100%;
+  padding: 32px;
+  background-color: $color-generic-white;
+  @include paragraph-medium();
+  color: $color-neutral-800;
+  box-sizing: border-box;
+}
+
+.iconWrapper {
+  display: flex;
+}

--- a/ui/src/components/error-boundary/error-boundary.tsx
+++ b/ui/src/components/error-boundary/error-boundary.tsx
@@ -1,0 +1,39 @@
+import { Button } from 'design-system/components/button/button'
+import { Icon, IconTheme, IconType } from 'design-system/components/icon/icon'
+import { Tooltip } from 'design-system/components/tooltip/tooltip'
+import { ErrorInfo, ReactNode } from 'react'
+import { ErrorBoundary as _ErrorBoundary } from 'react-error-boundary'
+import { STRING, translate } from 'utils/language'
+import styles from './error-boundary.module.scss'
+
+const logErrorToService = (error: Error, info: ErrorInfo) => {
+  // TODO: Pass error to Sentry here
+  console.error(error, info)
+}
+
+const FallbackComponent = ({
+  error,
+  resetErrorBoundary,
+}: {
+  error: { message: string }
+  resetErrorBoundary: () => void
+}) => (
+  <div className={styles.wrapper}>
+    <Tooltip content={error.message}>
+      <div className={styles.iconWrapper}>
+        <Icon type={IconType.Error} theme={IconTheme.Error} size={24} />
+      </div>
+    </Tooltip>
+    <span>Something went wrong!</span>
+    <Button label={translate(STRING.RETRY)} onClick={resetErrorBoundary} />
+  </div>
+)
+
+export const ErrorBoundary = ({ children }: { children: ReactNode }) => (
+  <_ErrorBoundary
+    FallbackComponent={FallbackComponent}
+    onError={logErrorToService}
+  >
+    {children}
+  </_ErrorBoundary>
+)

--- a/ui/src/design-system/components/plot/lazy-plot.tsx
+++ b/ui/src/design-system/components/plot/lazy-plot.tsx
@@ -1,3 +1,4 @@
+import { ErrorBoundary } from 'components/error-boundary/error-boundary'
 import React, { Suspense } from 'react'
 import { LoadingSpinner } from '../loading-spinner/loading-spinner'
 import { PlotProps } from './types'
@@ -6,6 +7,8 @@ const _Plot = React.lazy(() => import('./plot'))
 
 export const Plot = (props: PlotProps) => (
   <Suspense fallback={<LoadingSpinner />}>
-    <_Plot {...props} />
+    <ErrorBoundary>
+      <_Plot {...props} />
+    </ErrorBoundary>
   </Suspense>
 )

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -6495,6 +6495,7 @@ __metadata:
     prettier: "npm:2.8.4"
     react: "npm:^18.2.0"
     react-dom: "npm:^18.2.0"
+    react-error-boundary: "npm:^4.0.11"
     react-hook-form: "npm:^7.43.9"
     react-leaflet: "npm:^4.2.1"
     react-plotly.js: "npm:^2.6.0"
@@ -13415,6 +13416,17 @@ __metadata:
     react: ^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1 || ^18.0.0
     react-dom: ^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1 || ^18.0.0
   checksum: 0d60a0ea758529c32a706d0c69d70b69fb94de3c46442fffdee34f08f51ffceddbb5395b41dfd1565895653e9f60f98ca525835be9d5db1f16d6b22be12f4cd4
+  languageName: node
+  linkType: hard
+
+"react-error-boundary@npm:^4.0.11":
+  version: 4.0.11
+  resolution: "react-error-boundary@npm:4.0.11"
+  dependencies:
+    "@babel/runtime": "npm:^7.12.5"
+  peerDependencies:
+    react: ">=16.13.1"
+  checksum: 33dad3df7687971e65c7182d97f44bd618cb5d77d1c338e0a7c17c5cf7706a07b9055fffb771ff19bad750d40dd3cfd18d661a60b0518e73197e294dc185f18c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
In this PR we setup a generic error boundary component. We can wrap this around any component to catch errors instead of having the application crash when something unexpected happens. It can be used for larger components, like page components, but also for smaller ones for more granular control. In the future, this can be nice to wrap around components we know can be fragile.

Example where error is catched on page level. The button "Retry" will reset the component to its initial state.
<img width="1652" alt="Screenshot 2023-11-22 at 22 37 32" src="https://github.com/RolnickLab/ami-platform/assets/11680517/219ca8b9-dfed-4ced-a336-d92fbcee936d">

Example where error is catched on component level (error message is visible on icon hover):
<img width="1652" alt="Screenshot 2023-11-22 at 22 38 08" src="https://github.com/RolnickLab/ami-platform/assets/11680517/6c407ea6-8b63-46d2-93b2-2436331387eb">

Error message is visible on icon hover:
<img width="1652" alt="Screenshot 2023-11-22 at 22 38 10" src="https://github.com/RolnickLab/ami-platform/assets/11680517/c45f0c55-291e-47a7-bdf4-2588cc3977ca">
