### PR TITLE
Fix timeout on session detail pages with many species

### DIFF
--- a/ami/main/api/serializers.py
+++ b/ami/main/api/serializers.py
@@ -448,7 +448,8 @@ class TaxonListSerializer(DefaultSerializer):
         Return URL to the occurrences endpoint filtered by this taxon.
         """
 
-        params = self.context["request"].query_params
+        params = {}
+        params.update(dict(self.context["request"].query_params.items()))
         params.update({"determination": obj.pk})
 
         return reverse_with_params(

--- a/ami/main/api/serializers.py
+++ b/ami/main/api/serializers.py
@@ -1143,6 +1143,14 @@ class EventSerializer(DefaultSerializer):
 
         return offset
 
+    def get_occurrences_count(self, obj):
+        return obj.occurrences_count(
+            classification_threshold=get_active_classification_threshold(self.context["request"])
+        )
+
+    def get_taxa_count(self, obj):
+        return obj.taxa_count(classification_threshold=get_active_classification_threshold(self.context["request"]))
+
 
 class StorageStatusSerializer(serializers.Serializer):
     data_source = serializers.CharField(max_length=200)

--- a/ami/main/api/views.py
+++ b/ami/main/api/views.py
@@ -194,24 +194,6 @@ class EventViewSet(DefaultViewSet):
             duration=models.F("end") - models.F("start"),
         ).select_related("deployment", "project")
 
-        if self.action != "list":
-            qs = qs.annotate(
-                # detections_count=models.Count("captures__detections", distinct=True),
-                occurrences_count=models.Count(
-                    "occurrences",
-                    distinct=True,
-                    filter=models.Q(
-                        occurrences__determination_score__gte=get_active_classification_threshold(self.request)
-                    ),
-                ),
-                taxa_count=models.Count(
-                    "occurrences__determination",
-                    distinct=True,
-                    filter=models.Q(
-                        occurrences__determination_score__gte=get_active_classification_threshold(self.request)
-                    ),
-                ),
-            ).prefetch_related("occurrences", "occurrences__determination")
         return qs
 
 

--- a/ami/main/models.py
+++ b/ami/main/models.py
@@ -54,8 +54,6 @@ DEFAULT_RANKS = sorted(
     ]
 )
 
-DEFAULT_CONFIDENCE_THRESHOLD = 0.29
-
 
 # @TODO move to settings & make configurable
 _SOURCE_IMAGES_URL_BASE = "https://static.dev.insectai.org/ami-trapdata/vermont/snapshots/"
@@ -432,7 +430,7 @@ class Deployment(BaseModel):
         self.detections_count = Detection.objects.filter(Q(source_image__deployment=self)).count()
         self.occurrences_count = (
             self.occurrences.filter(
-                determination_score__gte=DEFAULT_CONFIDENCE_THRESHOLD,
+                determination_score__gte=settings.DEFAULT_CONFIDENCE_THRESHOLD,
                 event__isnull=False,
             )
             .distinct()
@@ -441,7 +439,7 @@ class Deployment(BaseModel):
         self.taxa_count = (
             Taxon.objects.filter(
                 occurrences__deployment=self,
-                occurrences__determination_score__gte=DEFAULT_CONFIDENCE_THRESHOLD,
+                occurrences__determination_score__gte=settings.DEFAULT_CONFIDENCE_THRESHOLD,
                 occurrences__event__isnull=False,
             )
             .distinct()
@@ -1951,7 +1949,7 @@ class Taxon(BaseModel):
         Use the request to generate the full media URLs.
         """
 
-        classification_threshold = classification_threshold or DEFAULT_CONFIDENCE_THRESHOLD
+        classification_threshold = classification_threshold or settings.DEFAULT_CONFIDENCE_THRESHOLD
 
         # Retrieve the URLs using a single optimized query
         qs = (

--- a/ami/utils/requests.py
+++ b/ami/utils/requests.py
@@ -1,0 +1,14 @@
+from django.conf import settings
+from django.forms import FloatField
+from rest_framework.request import Request
+
+
+def get_active_classification_threshold(request: Request) -> float:
+    # Look for a query param to filter by score
+    classification_threshold = request.query_params.get("classification_threshold")
+
+    if classification_threshold is not None:
+        classification_threshold = FloatField(required=False).clean(classification_threshold)
+    else:
+        classification_threshold = settings.DEFAULT_CONFIDENCE_THRESHOLD
+    return classification_threshold

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -1,6 +1,7 @@
 """
 Base settings to build other settings files upon.
 """
+
 from pathlib import Path
 
 import django_stubs_ext
@@ -359,3 +360,5 @@ SPECTACULAR_SETTINGS = {
 }
 # Your stuff...
 # ------------------------------------------------------------------------------
+
+DEFAULT_CONFIDENCE_THRESHOLD = env.float("DEFAULT_CONFIDENCE_THRESHOLD", default=0.29)  # type: ignore[no-untyped-call]


### PR DESCRIPTION
It turns out a single query that uses annotations to count the number of taxa and occurrences for a night is much much slower than using separate queries.

This also was a chance to standardize how the `confidence_threshold` parameter is used. Most views should now look for this query parameter in the current request when counting or displaying occurrences or detected taxa. It falls back to the `DEFAULT_CONFIDENCE_THRESHOLD` in the Django settings, which is also an env var.