### PR TITLE
Method to manually approve new users for write operations

### DIFF
--- a/.envs/.local/.django
+++ b/.envs/.local/.django
@@ -1,6 +1,8 @@
 # General
 # ------------------------------------------------------------------------------
+DJANGO_SETTINGS_MODULE="config.settings.local"
 USE_DOCKER=yes
+DJANGO_DEBUG=True
 IPYTHONDIR=/app/.ipython
 # Redis
 # ------------------------------------------------------------------------------
@@ -16,3 +18,5 @@ CELERY_FLOWER_PASSWORD=BEQgmCtgyrFieKNoGTsux9YIye0I7P5Q7vEgfJD2C4jxmtHDetFaE2jhS
 # Monitoring
 NEW_RELIC_CONFIG_FILE=newrelic.ini
 NEW_RELIC_ENVIRONMENT=development
+
+DJANGO_CSRF_TRUSTED_ORIGINS=http://localhost:3000,

--- a/ami/base/permissions.py
+++ b/ami/base/permissions.py
@@ -2,8 +2,30 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from rest_framework import permissions
+
 if TYPE_CHECKING:
     from django.contrib.auth.models import User
+
+
+def is_active_staff(user: User) -> bool:
+    return bool(
+        user.is_authenticated and user.is_staff and user.is_active,
+    )
+
+
+class IsActiveStaffOrReadOnly(permissions.BasePermission):
+    """
+    The request is by a staff member, or is a read-only request.
+    """
+
+    def has_permission(self, request, view):
+        return bool(
+            request.method in permissions.SAFE_METHODS
+            or request.user
+            and request.user.is_authenticated
+            and is_active_staff(request.user)  # type: ignore # @TODO why?
+        )
 
 
 def add_object_level_permissions(user: User | None, response_data: dict) -> dict:
@@ -16,7 +38,7 @@ def add_object_level_permissions(user: User | None, response_data: dict) -> dict
     @TODO @IMPORTANT At least check if they are the owner of the project.
     """
     permissions = response_data.get("user_permissions", set())
-    if user and user.is_authenticated:
+    if user and is_active_staff(user):
         permissions.update(["update"])
         if user.is_superuser:
             permissions.update(["delete"])
@@ -31,7 +53,7 @@ def add_collection_level_permissions(user: User | None, response_data: dict) -> 
     If the user is logged in, they can create new objects of any type.
     """
     permissions = response_data.get("user_permissions", set())
-    if user and user.is_authenticated:
+    if user and is_active_staff(user):
         permissions.add("create")
     response_data["user_permissions"] = permissions
     return response_data

--- a/ami/main/api/views.py
+++ b/ami/main/api/views.py
@@ -9,7 +9,7 @@ from django.forms import BooleanField, CharField, IntegerField
 from django.utils import timezone
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import exceptions as api_exceptions
-from rest_framework import permissions, viewsets
+from rest_framework import viewsets
 from rest_framework.decorators import action
 from rest_framework.filters import SearchFilter
 from rest_framework.response import Response
@@ -17,6 +17,7 @@ from rest_framework.views import APIView
 
 from ami import tasks
 from ami.base.filters import NullsLastOrderingFilter
+from ami.base.permissions import IsActiveStaffOrReadOnly
 from ami.utils.requests import get_active_classification_threshold
 
 from ..models import (
@@ -86,7 +87,7 @@ class DefaultViewSetMixin:
     filterset_fields = []
     ordering_fields = ["created_at", "updated_at"]
     search_fields = []
-    permission_classes = [permissions.IsAuthenticatedOrReadOnly]
+    permission_classes = [IsActiveStaffOrReadOnly]
 
 
 class DefaultViewSet(DefaultViewSetMixin, viewsets.ModelViewSet):
@@ -693,7 +694,7 @@ class ClassificationViewSet(DefaultViewSet):
 
 
 class SummaryView(APIView):
-    permission_classes = [permissions.IsAuthenticatedOrReadOnly]
+    permission_classes = [IsActiveStaffOrReadOnly]
     filterset_fields = ["project"]
 
     def get(self, request):
@@ -770,7 +771,7 @@ class StorageStatus(APIView):
     Return the status of the storage connection.
     """
 
-    permission_classes = [permissions.IsAuthenticatedOrReadOnly]
+    permission_classes = [IsActiveStaffOrReadOnly]
     serializer_class = StorageStatusSerializer
 
     def post(self, request):

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -314,7 +314,7 @@ REST_FRAMEWORK = {
         "rest_framework.authentication.SessionAuthentication",
         "rest_framework.authentication.TokenAuthentication",
     ),
-    "DEFAULT_PERMISSION_CLASSES": ("rest_framework.permissions.IsAuthenticatedOrReadOnly",),
+    "DEFAULT_PERMISSION_CLASSES": ("ami.base.permissions.IsActiveStaffOrReadOnly",),
     # "DEFAULT_PERMISSION_CLASSES": ("rest_framework.permissions.AllowAny",),
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
     "DEFAULT_PAGINATION_CLASS": "ami.base.pagination.LimitOffsetPaginationWithPermissions",


### PR DESCRIPTION
Previously new users would immediately have access to all write & destructive methods. 

With this update, anyone can still make an account and use read-only features. However users will need to be approved by an administrator before they can make an edits (set to Staff). 

This is a simple, intermediary method of limiting access before we have a proper role-based and object-level permissions.