### PR TITLE
Error handling for jobs

### DIFF
--- a/ami/jobs/management/commands/update_stale_jobs.py
+++ b/ami/jobs/management/commands/update_stale_jobs.py
@@ -8,14 +8,22 @@ from ami.jobs.models import Job, JobState
 
 class Command(BaseCommand):
     help = (
-        "Update the status of all jobs that are not in a final state "
-        "and have not been updated in the last 24 hours."
+        "Update the status of all jobs that are not in a final state " "and have not been updated in the last X hours."
     )
+
+    # Add argument for the number of hours to consider a job stale
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--hours",
+            type=int,
+            default=Job.FAILED_CUTOFF_HOURS,
+            help="Number of hours to consider a job stale",
+        )
 
     def handle(self, *args, **options):
         stale_jobs = Job.objects.filter(
             status__in=JobState.running_states(),
-            updated_at__lt=timezone.now() - timezone.timedelta(hours=24),
+            updated_at__lt=timezone.now() - timezone.timedelta(hours=options["hours"]),
         )
 
         for job in stale_jobs:

--- a/ami/jobs/management/commands/update_stale_jobs.py
+++ b/ami/jobs/management/commands/update_stale_jobs.py
@@ -1,0 +1,30 @@
+from celery import states
+from celery.result import AsyncResult
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+
+from ami.jobs.models import Job, JobState
+
+
+class Command(BaseCommand):
+    help = (
+        "Update the status of all jobs that are not in a final state "
+        "and have not been updated in the last 24 hours."
+    )
+
+    def handle(self, *args, **options):
+        stale_jobs = Job.objects.filter(
+            status__in=JobState.running_states(),
+            updated_at__lt=timezone.now() - timezone.timedelta(hours=24),
+        )
+
+        for job in stale_jobs:
+            task = AsyncResult(job.task_id) if job.task_id else None
+            if task:
+                job.update_status(task.state, save=False)
+                job.save()
+                self.stdout.write(self.style.SUCCESS(f"Updated status of job {job.pk} to {task.state}"))
+            else:
+                self.stdout.write(self.style.WARNING(f"Job {job.pk} has no associated task, setting status to FAILED"))
+                job.update_status(states.FAILURE, save=False)
+                job.save()

--- a/ami/jobs/models.py
+++ b/ami/jobs/models.py
@@ -45,6 +45,14 @@ class JobState(str, OrderedEnum):
     RECEIVED = "RECEIVED"
     UNKNOWN = "UNKNOWN"
 
+    @classmethod
+    def running_states(cls):
+        return [cls.CREATED, cls.PENDING, cls.STARTED, cls.RETRY]
+
+    @classmethod
+    def final_states(cls):
+        return [cls.SUCCESS, cls.FAILURE, cls.REVOKED]
+
 
 def get_status_label(status: JobState, progress: float) -> str:
     """

--- a/ami/jobs/models.py
+++ b/ami/jobs/models.py
@@ -47,11 +47,15 @@ class JobState(str, OrderedEnum):
 
     @classmethod
     def running_states(cls):
-        return [cls.CREATED, cls.PENDING, cls.STARTED, cls.RETRY]
+        return [cls.CREATED, cls.PENDING, cls.STARTED, cls.RETRY, cls.CANCELING, cls.UNKNOWN]
 
     @classmethod
     def final_states(cls):
         return [cls.SUCCESS, cls.FAILURE, cls.REVOKED]
+
+    @classmethod
+    def failed_states(cls):
+        return [cls.FAILURE, cls.REVOKED, cls.UNKNOWN]
 
 
 def get_status_label(status: JobState, progress: float) -> str:
@@ -247,6 +251,9 @@ class JobLogHandler(logging.Handler):
 
 class Job(BaseModel):
     """A job to be run by the scheduler"""
+
+    # Hide old failed jobs after 3 days
+    FAILED_CUTOFF_HOURS = 24 * 3
 
     name = models.CharField(max_length=255)
     queue = models.CharField(max_length=255, default="default")


### PR DESCRIPTION
- Continue job if one batch fails. 
- Add very basic exception handling and logging at the controller level
- Hide failed jobs that are 3 days or older (by default)
- Management command for cleaning up stale/old jobs