### PR TITLE
Initial methods to skip already-processed images.

### DIFF
--- a/ami/base/models.py
+++ b/ami/base/models.py
@@ -13,7 +13,7 @@ class BaseModel(models.Model):
         """All django models should have this method."""
         if hasattr(self, "name"):
             name = getattr(self, "name") or "Untitled"
-            return name
+            return f"#{self.pk} {name}"
         else:
             return f"{self.__class__.__name__} #{self.pk}"
 

--- a/ami/jobs/models.py
+++ b/ami/jobs/models.py
@@ -401,6 +401,7 @@ class Job(BaseModel):
                     deployment=self.deployment,
                     source_images=[self.source_image_single] if self.source_image_single else None,
                     job_id=self.pk,
+                    skip_processed=True,
                     # shuffle=self.shuffle,
                 )
             )
@@ -452,7 +453,7 @@ class Job(BaseModel):
                     "process",
                     status=JobState.STARTED,
                     progress=(i + 1) / len(chunks),
-                    proccessed=(i + 1) * CHUNK_SIZE,
+                    processed=(i + 1) * CHUNK_SIZE,
                     remaining=image_count - (i + 1) * CHUNK_SIZE,
                     detections=total_detections,
                     classifications=total_classifications,

--- a/ami/jobs/models.py
+++ b/ami/jobs/models.py
@@ -448,7 +448,7 @@ class Job(BaseModel):
                     continue
 
                 total_detections += len(results.detections)
-                total_classifications += len(results.classifications)
+                total_classifications += len([c for d in results.detections for c in d.classifications])
                 self.progress.update_stage(
                     "process",
                     status=JobState.STARTED,

--- a/ami/main/api/views.py
+++ b/ami/main/api/views.py
@@ -232,7 +232,7 @@ class SourceImageViewSet(DefaultViewSet):
                 .filter(has_detections=has_detections)
                 .order_by(
                     "?"
-                )  # Random order is here for our demo ML backend to limit the same images from being proccessed
+                )  # Random order is here for our demo ML backend to limit the same images from being processed
                 # @TODO remove this when we have a real queue for the ML backend
             )
         return queryset

--- a/ami/main/models.py
+++ b/ami/main/models.py
@@ -1393,6 +1393,9 @@ class Classification(BaseModel):
     class Meta:
         ordering = ["-created_at", "-score"]
 
+    def __str__(self) -> str:
+        return f"<Classification #{self.pk} - {self.taxon_id} {self.score:.2f} with {self.algorithm_id}>"
+
 
 @final
 class Detection(BaseModel):
@@ -1537,6 +1540,9 @@ class Detection(BaseModel):
             self.update_calculated_fields(save=True)
         # if not self.occurrence:
         #     self.associate_new_occurrence()
+
+    def __str__(self) -> str:
+        return f"<Detection #{self.pk} from SourceImage #{self.source_image_id} with {self.detection_algorithm_id}>"
 
 
 @final

--- a/ami/main/models.py
+++ b/ami/main/models.py
@@ -1394,7 +1394,7 @@ class Classification(BaseModel):
         ordering = ["-created_at", "-score"]
 
     def __str__(self) -> str:
-        return f"<Classification #{self.pk} - {self.taxon_id} {self.score:.2f} with {self.algorithm_id}>"
+        return f"#{self.pk} to Taxon #{self.taxon_id} ({self.score:.2f}) by Algorithm #{self.algorithm_id}"
 
 
 @final
@@ -1542,7 +1542,7 @@ class Detection(BaseModel):
         #     self.associate_new_occurrence()
 
     def __str__(self) -> str:
-        return f"<Detection #{self.pk} from SourceImage #{self.source_image_id} with {self.detection_algorithm_id}>"
+        return f"#{self.pk} from SourceImage #{self.source_image_id} with Algorithm #{self.detection_algorithm_id}"
 
 
 @final

--- a/ami/ml/models/algorithm.py
+++ b/ami/ml/models/algorithm.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from ami.main.models import Classification
+    from ami.ml.models import Pipeline
 
 import typing
 
@@ -27,6 +28,7 @@ class Algorithm(BaseModel):
     # api_base_url = models.URLField(blank=True)
     # api = models.CharField(max_length=255, blank=True)
 
+    pipelines: models.QuerySet[Pipeline]
     classifications: models.QuerySet[Classification]
 
     class Meta:

--- a/ami/ml/models/algorithm.py
+++ b/ami/ml/models/algorithm.py
@@ -23,7 +23,7 @@ class Algorithm(BaseModel):
     description = models.TextField(blank=True)
     version = models.IntegerField(default=1)
     version_name = models.CharField(max_length=255, blank=True)
-    url = models.URLField(blank=True)
+    url = models.URLField(blank=True)  # URL to the model homepage, origin or docs (huggingface, wandb, etc.)
 
     # api_base_url = models.URLField(blank=True)
     # api = models.CharField(max_length=255, blank=True)

--- a/ami/ml/models/pipeline.py
+++ b/ami/ml/models/pipeline.py
@@ -41,12 +41,12 @@ def filter_processed_images(
     for image in images:
         existing_detections = image.detections.filter(detection_algorithm__in=pipeline_algorithms)
         if not existing_detections.exists():
-            logger.info(f"Image {image} has no existing detections from pipeline {pipeline}")
+            logger.debug(f"Image {image} has no existing detections from pipeline {pipeline}")
             # If there are no existing detections from this pipeline, send the image
             yield image
         elif existing_detections.filter(classifications__isnull=True).exists():
             # Check if there are detections with no classifications
-            logger.info(f"Image {image} has existing detections with no classifications from pipeline {pipeline}")
+            logger.debug(f"Image {image} has existing detections with no classifications from pipeline {pipeline}")
             yield image
         else:
             # If there are existing detections with classifications,
@@ -55,7 +55,7 @@ def filter_processed_images(
                 classifications__algorithm__in=pipeline_algorithms
             )
             if detections_needing_classification.exists():
-                logger.info(
+                logger.debug(
                     f"Image {image} has existing detections that haven't been classified by the pipeline: {pipeline}"
                 )
                 logger.warn(
@@ -65,7 +65,9 @@ def filter_processed_images(
                 yield image
             else:
                 # If all detections have been classified by the pipeline, skip the image
-                logger.info(f"Image {image} has existing detections classified by the pipeline: {pipeline}, skipping!")
+                logger.debug(
+                    f"Image {image} has existing detections classified by the pipeline: {pipeline}, skipping!"
+                )
                 continue
 
 

--- a/ami/ml/models/pipeline.py
+++ b/ami/ml/models/pipeline.py
@@ -44,7 +44,7 @@ def filter_processed_images(
             logger.info(f"Image {image} has no existing detections from pipeline {pipeline}")
             # If there are no existing detections from this pipeline, send the image
             yield image
-        elif not existing_detections.filter(classifications__isnull=True).exists():
+        elif existing_detections.filter(classifications__isnull=True).exists():
             # Check if there are detections with no classifications
             logger.info(f"Image {image} has existing detections with no classifications from pipeline {pipeline}")
             yield image

--- a/ami/ml/schemas.py
+++ b/ami/ml/schemas.py
@@ -47,7 +47,7 @@ class SourceImageResponse(pydantic.BaseModel):
     url: str
 
 
-PipelineChoice = typing.Literal[
+KnownPipelineChoices = typing.Literal[
     "panama_moths_2023",
     "quebec_vermont_moths_2023",
     "uk_denmark_moths_2023",
@@ -55,12 +55,13 @@ PipelineChoice = typing.Literal[
 
 
 class PipelineRequest(pydantic.BaseModel):
-    pipeline: PipelineChoice
+    pipeline: str
     source_images: list[SourceImageRequest]
 
 
 class PipelineResponse(pydantic.BaseModel):
-    pipeline: PipelineChoice
+    # pipeline: PipelineChoice
+    pipeline: str
     total_time: float
     source_images: list[SourceImageResponse]
     detections: list[DetectionResponse]

--- a/ami/ml/schemas.py
+++ b/ami/ml/schemas.py
@@ -15,6 +15,16 @@ class BoundingBox(pydantic.BaseModel):
         return cls(x1=coords[0], y1=coords[1], x2=coords[2], y2=coords[3])
 
 
+class ClassificationResponse(pydantic.BaseModel):
+    classification: str
+    labels: list[str] = []
+    scores: list[float] = []
+    inference_time: float | None = None
+    algorithm: str | None = None
+    timestamp: datetime.datetime
+    terminal: bool = True
+
+
 class DetectionResponse(pydantic.BaseModel):
     source_image_id: str
     bbox: BoundingBox
@@ -22,17 +32,7 @@ class DetectionResponse(pydantic.BaseModel):
     algorithm: str | None = None
     timestamp: datetime.datetime
     crop_image_url: str | None = None
-
-
-class ClassificationResponse(pydantic.BaseModel):
-    source_image_id: str
-    bbox: BoundingBox | None = None
-    classification: str
-    labels: list[str] = []
-    scores: list[float] = []
-    inference_time: float | None = None
-    algorithm: str | None = None
-    timestamp: datetime.datetime
+    classifications: list[ClassificationResponse] = []
 
 
 class SourceImageRequest(pydantic.BaseModel):
@@ -65,4 +65,3 @@ class PipelineResponse(pydantic.BaseModel):
     total_time: float
     source_images: list[SourceImageResponse]
     detections: list[DetectionResponse]
-    classifications: list[ClassificationResponse]

--- a/ami/ml/tests.py
+++ b/ami/ml/tests.py
@@ -2,8 +2,9 @@ import datetime
 
 from django.test import TestCase
 
-from ami.main.models import SourceImage
-from ami.ml.models.pipeline import save_results
+from ami.main.models import Project, SourceImage, SourceImageCollection
+from ami.ml.models import Algorithm, Pipeline
+from ami.ml.models.pipeline import collect_images, save_results
 from ami.ml.schemas import (
     BoundingBox,
     ClassificationResponse,
@@ -15,47 +16,83 @@ from ami.ml.schemas import (
 
 class TestPipeline(TestCase):
     def setUp(self):
-        self.test_images = [SourceImage.objects.create()]
+        self.project = Project.objects.create(name="Test Project")
+        # Create test images and collection
+        self.test_images = [
+            SourceImage.objects.create(path="test1-20240101000000.jpg"),
+            SourceImage.objects.create(path="test2-20240101001000.jpg"),
+        ]
+        self.image_collection = SourceImageCollection.objects.create(
+            name="Test Collection",
+            project=self.project,
+        )
+        self.image_collection.images.set(self.test_images)
+
+        # Create test pipeline and algorithms
+        self.pipeline = Pipeline.objects.create(
+            name="Test Pipeline",
+        )
+        algorithms = [
+            Algorithm.objects.create(name="Test Object Detector"),
+            Algorithm.objects.create(name="Test Classifier"),
+        ]
+        self.pipeline.algorithms.set(algorithms)
+
+    def test_create_pipeline(self):
+        self.assertEqual(self.pipeline.slug, "test-pipeline")
+        self.assertEqual(self.pipeline.algorithms.count(), 2)
+
+        for algorithm in self.pipeline.algorithms.all():
+            self.assertIn(algorithm.key, ["test-object-detector", "test-classifier"])
+
+    def test_collect_images(self):
+        images = list(collect_images(collection=self.image_collection, pipeline=self.pipeline))
+        assert len(images) == 2
+
+    def fake_pipeline_results(self, source_images: list[SourceImage]):
+        source_image_results = [SourceImageResponse(id=image.pk, url=image.path) for image in source_images]
+        detection_results = [
+            DetectionResponse(
+                source_image_id=image.pk,
+                bbox=BoundingBox(x1=0.0, y1=0.0, x2=1.0, y2=1.0),
+                inference_time=0.4,
+                algorithm=self.pipeline.algorithms.all()[0].name,
+                timestamp=datetime.datetime.now(),
+            )
+            for image in self.test_images
+        ]
+        classification_results = [
+            ClassificationResponse(
+                source_image_id=image.pk,
+                classification="Test taxon",
+                bbox=BoundingBox(x1=0.0, y1=0.0, x2=1.0, y2=1.0),
+                labels=["Test taxon"],
+                scores=[0.64333],
+                algorithm=self.pipeline.algorithms.all()[1].name,
+                timestamp=datetime.datetime.now(),
+            )
+            for image in self.test_images
+        ]
+        fake_results = PipelineResponse(
+            pipeline=self.pipeline.slug,
+            total_time=0.0,
+            source_images=source_image_results,
+            detections=detection_results,
+            classifications=classification_results,
+        )
+        return fake_results
 
     def test_save_results(self):
-        source_image_id = str(self.test_images[0].pk)
-        fake_results = PipelineResponse(
-            pipeline="panama_moths_2023",
-            total_time=0.0,
-            source_images=[
-                SourceImageResponse(
-                    id=source_image_id,
-                    url="https://example.com",
-                ),
-            ],
-            detections=[
-                DetectionResponse(
-                    source_image_id=source_image_id,
-                    bbox=BoundingBox(x1=0.0, y1=0.0, x2=1.0, y2=1.0),
-                    inference_time=0.4,
-                    algorithm="Test Detector",
-                    timestamp=datetime.datetime.now(),
-                ),
-            ],
-            classifications=[
-                ClassificationResponse(
-                    source_image_id=source_image_id,
-                    classification="Test taxon",
-                    bbox=BoundingBox(x1=0.0, y1=0.0, x2=1.0, y2=1.0),
-                    labels=["Test taxon"],
-                    scores=[0.64333],
-                    algorithm="Test Classifier",
-                    timestamp=datetime.datetime.now(),
-                ),
-            ],
-        )
-        saved_objects = save_results(fake_results)
+        saved_objects = save_results(self.fake_pipeline_results(self.test_images))
 
         for image in self.test_images:
             image.save()
             self.assertEqual(image.detections_count, 1)
         print(saved_objects)
 
-    def test_save_multiple(self):
-        for _ in range(3):
-            self.test_save_results()
+    def test_skip_existing_results(self):
+        images = list(collect_images(collection=self.image_collection, pipeline=self.pipeline))
+        self.assertEqual(len(images), self.image_collection.images.count())
+        save_results(self.fake_pipeline_results(images))
+        images_again = list(collect_images(collection=self.image_collection, pipeline=self.pipeline))
+        self.assertEqual(len(images_again), 0)

--- a/ami/ml/tests.py
+++ b/ami/ml/tests.py
@@ -42,7 +42,7 @@ class TestPipeline(TestCase):
 
     def test_create_pipeline(self):
         self.assertEqual(self.pipeline.slug, "test-pipeline")
-        self.assertEqual(self.pipeline.algorithms.count(), 2)
+        self.assertEqual(self.pipeline.algorithms.count(), 3)
 
         for algorithm in self.pipeline.algorithms.all():
             self.assertIn(algorithm.key, ["test-object-detector", "test-filter", "test-classifier"])

--- a/ui/src/data-services/models/occurrence-details.ts
+++ b/ui/src/data-services/models/occurrence-details.ts
@@ -12,6 +12,7 @@ export interface Identification {
   overridden?: boolean
   taxon: Taxon
   userPermissions: UserPermission[]
+  createdAt: string
 }
 
 export interface HumanIdentification extends Identification {
@@ -57,6 +58,7 @@ export class OccurrenceDetails extends Occurrence {
           taxon,
           user: { id: `${i.user.id}`, name: i.user.name, image: i.user.image },
           userPermissions: i.user_permissions,
+          createdAt: i.created_at,
         }
 
         return identification
@@ -76,6 +78,7 @@ export class OccurrenceDetails extends Occurrence {
           taxon,
           score: p.score,
           userPermissions: p.user_permissions,
+          createdAt: p.created_at,
         }
 
         return prediction

--- a/ui/src/design-system/components/identification/identification-summary/identification-summary.tsx
+++ b/ui/src/design-system/components/identification/identification-summary/identification-summary.tsx
@@ -1,4 +1,9 @@
+import {
+  Identification
+} from 'data-services/models/occurrence-details'
+import { Tooltip } from 'design-system/components/tooltip/tooltip'
 import { ReactNode } from 'react'
+import { getFormatedDateTimeString } from 'utils/date/getFormatedDateTimeString/getFormatedDateTimeString'
 import { STRING, translate } from 'utils/language'
 import { Icon, IconTheme, IconType } from '../../icon/icon'
 import styles from './identification-summary.module.scss'
@@ -9,33 +14,41 @@ interface IdentificationSummaryProps {
     name: string
     image?: string
   }
+  identification: Identification
 }
 
 export const IdentificationSummary = ({
   children,
   user,
-}: IdentificationSummaryProps) => (
-  <div>
-    <div className={styles.user}>
-      {user ? (
-        <div className={styles.profileImage}>
-          {user.image ? (
-            <img src={user.image} alt="" />
-          ) : (
-            <Icon
-              type={IconType.Photograph}
-              theme={IconTheme.Primary}
-              size={16}
-            />
-          )}
-        </div>
-      ) : (
-        <Icon type={IconType.BatchId} theme={IconTheme.Primary} size={16} />
-      )}
-      <span className={styles.username}>
-        {user?.name ?? translate(STRING.MACHINE_SUGGESTION)}
-      </span>
+  identification,
+}: IdentificationSummaryProps) => {
+  const formattedTime = getFormatedDateTimeString({ date: new Date(identification.createdAt) });
+
+  return (
+    <div>
+      <div className={styles.user}>
+        {user ? (
+          <div className={styles.profileImage}>
+            {user.image ? (
+              <img src={user.image} alt="" />
+            ) : (
+              <Icon
+                type={IconType.Photograph}
+                theme={IconTheme.Primary}
+                size={16}
+              />
+            )}
+          </div>
+        ) : (
+          <Icon type={IconType.BatchId} theme={IconTheme.Primary} size={16} />
+        )}
+        <Tooltip content={formattedTime}>
+          <span className={styles.username}>
+            {user?.name ?? translate(STRING.MACHINE_SUGGESTION)}
+          </span>
+        </Tooltip>
+      </div>
+      {children}
     </div>
-    {children}
-  </div>
-)
+  );
+};

--- a/ui/src/pages/occurrence-details/identification-card/identification-card.tsx
+++ b/ui/src/pages/occurrence-details/identification-card/identification-card.tsx
@@ -56,7 +56,8 @@ export const IdentificationCard = ({
   return (
     <div className={styles.identificationCard}>
       <div className={styles.content}>
-        <IdentificationSummary user={user}>
+
+        <IdentificationSummary user={user} identification={identification}>
           {identification.applied && (
             <StatusLabel label={translate(STRING.ID_APPLIED)} />
           )}


### PR DESCRIPTION
- Adds method to store and check what images and what detections have been processed by what algorithms
- Updates the ML backend schema to nest detections and classifications under the source image response, to more readability associate related objects
- Add new tests
- Fix related bugs & add new logging related to these features

Future work:
- Populate the algorithm metadata to all existing classifications so they won't be reprocessed
- Add support for reusing detections if only the classification algorithm has changed
- Reduce logging related to this change