### PR TITLE
Show softmax score in session detail view

### DIFF
--- a/ui/src/data-services/models/capture.ts
+++ b/ui/src/data-services/models/capture.ts
@@ -7,6 +7,7 @@ export type CaptureDetection = {
   bbox: number[]
   id: string
   label: string
+  score: number
   occurrenceId?: string
 }
 
@@ -18,16 +19,28 @@ export class Capture {
     this._capture = capture
 
     if (capture.detections?.length) {
-      this._detections = capture.detections.map((detection: any) => ({
-        bbox: detection.bbox,
-        id: `${detection.id}`,
-        label: detection.occurrence
-          ? detection.occurrence.determination.name
-          : detection.id,
-        occurrenceId: detection.occurrence
-          ? `${detection.occurrence.id}`
-          : undefined,
-      }))
+      this._detections = capture.detections.map((detection: any) => {
+        const makeLabel = (occurrence: any) => {
+          if (occurrence && occurrence.determination) {
+            const { name } = occurrence.determination;
+            const determination_score = occurrence.determination_score;
+            if (determination_score !== undefined) {
+              const scorePercentage = Math.round(determination_score * 100).toString();
+              return `${name} (${scorePercentage}%)`;
+            }
+            return name;
+          }
+          return detection.id;
+        };
+
+        return {
+          bbox: detection.bbox,
+          id: `${detection.id}`,
+          label: makeLabel(detection.occurrence),
+          score: detection.score,
+          occurrenceId: detection.occurrence ? `${detection.occurrence.id}` : undefined,
+        };
+      });
     }
   }
 


### PR DESCRIPTION
This was requested to help with a grant proposal, so adding quickly to the UI. But ideally we want to show much more information about each detection (top N results, by which algorithm, show family level predictions, etc). So need some new designs to pack all that in somewhere. 

One approach: 

<img width="720" alt="image" src="https://github.com/RolnickLab/ami-platform/assets/158175/bc8f9800-c7d3-4587-a5c6-47ddaa7f92cd">

It might be nice to incorporate the identification status visualization that appears elsewhere in the app, but I need help styling it!

<img width="613" alt="image" src="https://github.com/RolnickLab/ami-platform/assets/158175/d067f6d6-55fa-41d3-834b-f5da342de475">

