### PR TITLE
Add automatic query caching

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -87,6 +87,7 @@ THIRD_PARTY_APPS = [
     "drf_spectacular",
     "django_filters",
     "anymail",
+    "cachalot",
 ]
 
 LOCAL_APPS = [

--- a/docs/diagrams/state.mermaid
+++ b/docs/diagrams/state.mermaid
@@ -1,0 +1,8 @@
+stateDiagram-v2
+    Idle
+    state Idle {
+        next -- third
+    }
+    note right of Idle
+        This is the initial state
+    end note

--- a/docs/diagrams/state.mermaid
+++ b/docs/diagrams/state.mermaid
@@ -1,8 +1,0 @@
-stateDiagram-v2
-    Idle
-    state Idle {
-        next -- third
-    }
-    note right of Idle
-        This is the initial state
-    end note

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,6 +15,7 @@ rich==13.5
 pydantic<2.0  # Less than 2.0 because of django pydantic field
 django-pydantic-field==0.2.11
 sentry-sdk==1.40.4  # https://github.com/getsentry/sentry-python
+django-cachalot
 
 # Django
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
This will greatly speed up views that request the same data. Caching will need to become more nuanced when data is processing and we are making many DB writes per second. However this will help make a few pages less painful to load during this weeks demos and testing.