### PR TITLE
Tweak gallery layout for large screens

### DIFF
--- a/ui/src/components/gallery/gallery.module.scss
+++ b/ui/src/components/gallery/gallery.module.scss
@@ -5,10 +5,14 @@
 .gallery {
   position: relative;
   display: grid;
-  grid-template-columns: 1fr 1fr 1fr 1fr 1fr;
+  grid-template-columns: 1fr 1fr 1fr 1fr 1fr 1fr 1fr;
   gap: 16px;
   width: 100%;
   min-height: 320px;
+
+  &.large {
+    grid-template-columns: 1fr 1fr 1fr 1fr 1fr !important;
+  }
 
   &.loading {
     margin: 0;
@@ -28,6 +32,16 @@
   display: flex;
   align-items: center;
   justify-content: center;
+}
+
+@media only screen and (max-width: $large-screen-breakpoint) {
+  .gallery {
+    grid-template-columns: 1fr 1fr 1fr 1fr 1fr !important;
+
+    &.large {
+      grid-template-columns: 1fr 1fr 1fr !important;
+    }
+  }
 }
 
 @media only screen and (max-width: $medium-screen-breakpoint) {

--- a/ui/src/design-system/components/card/card.module.scss
+++ b/ui/src/design-system/components/card/card.module.scss
@@ -8,6 +8,7 @@
   border: 1px solid $color-neutral-100;
   border-radius: 8px;
   overflow: hidden;
+  height: 100%;
 }
 
 .square {
@@ -36,7 +37,7 @@
 .content {
   display: flex;
   align-items: flex-start;
-  justify-content: flex-start;
+  justify-content: center;
   flex-direction: column;
   flex: 1;
   padding: 12px 16px;

--- a/ui/src/design-system/variables/variables.scss
+++ b/ui/src/design-system/variables/variables.scss
@@ -2,11 +2,13 @@
  * Screen size definitions:
  * Small screen:    <= 720px
  * Medium screen:   > 720px && <= 1024px
- * Large screen:    > 1024px
+ * Large screen:    > 1024px && <= 1440px
+ * Large+ screen:   > 1440px
  */
 
 $small-screen-breakpoint: 720px;
 $medium-screen-breakpoint: 1024px;
+$large-screen-breakpoint: 1440px;
 
 /* Other */
 $page-min-width: 320px;


### PR DESCRIPTION
If screen size is > 1440px, we show 7 instead of 5 columns. For the large gallery view (used in project overview page), we show 5 instead of 3 columns in this case.