### PR TITLE
Small tweaks to deployment location

### DIFF
--- a/ui/src/components/form/form-field.tsx
+++ b/ui/src/components/form/form-field.tsx
@@ -12,11 +12,13 @@ export const FormField = <
   config,
   control,
   name,
+  step,
   type,
   onBlur,
 }: Pick<ControllerProps<TFieldValues, TName>, 'name' | 'control'> & {
   config: FormConfig
   type?: 'number' | 'text' | 'password'
+  step?: number
   onBlur?: (e: FocusEvent<HTMLInputElement>) => void
 }) => {
   const fieldConfig = config[name]
@@ -37,6 +39,7 @@ export const FormField = <
           }
           error={fieldState.error?.message}
           description={fieldConfig.description}
+          step={step}
           onBlur={(e) => {
             onBlur?.(e)
             field.onBlur()

--- a/ui/src/components/form/form-field.tsx
+++ b/ui/src/components/form/form-field.tsx
@@ -9,16 +9,18 @@ export const FormField = <
   TFieldValues extends FieldValues,
   TName extends FieldPath<TFieldValues>
 >({
-  config,
-  control,
   name,
-  step,
+  control,
+  config,
   type,
+  step,
+  noArrows,
   onBlur,
 }: Pick<ControllerProps<TFieldValues, TName>, 'name' | 'control'> & {
   config: FormConfig
   type?: 'number' | 'text' | 'password'
   step?: number
+  noArrows?: boolean
   onBlur?: (e: FocusEvent<HTMLInputElement>) => void
 }) => {
   const fieldConfig = config[name]
@@ -37,9 +39,10 @@ export const FormField = <
               ? `${fieldConfig.label} *`
               : fieldConfig.label
           }
-          error={fieldState.error?.message}
           description={fieldConfig.description}
+          error={fieldState.error?.message}
           step={step}
+          noArrows={noArrows}
           onBlur={(e) => {
             onBlur?.(e)
             field.onBlur()

--- a/ui/src/design-system/components/input/input.module.scss
+++ b/ui/src/design-system/components/input/input.module.scss
@@ -100,6 +100,20 @@
   &:disabled {
     opacity: 0.5;
   }
+
+  &.noArrows {
+    /* Chrome, Safari, Edge, Opera */
+    &::-webkit-outer-spin-button,
+    &::-webkit-inner-spin-button {
+      -webkit-appearance: none;
+      margin: 0;
+    }
+
+    /* Firefox */
+    &[type='number'] {
+      -moz-appearance: textfield;
+    }
+  }
 }
 
 .passwordButtonContainer {

--- a/ui/src/design-system/components/input/input.tsx
+++ b/ui/src/design-system/components/input/input.tsx
@@ -22,8 +22,9 @@ interface InputProps {
   label: string
   name: string
   placeholder?: string
-  value?: string | number
+  step?: number
   type?: 'text' | 'number' | 'password'
+  value?: string | number
   onBlur?: (e: FocusEvent<HTMLInputElement>) => void
   onChange?: (e: ChangeEvent<HTMLInputElement>) => void
   onFocus?: (e: FocusEvent<HTMLInputElement>) => void
@@ -37,6 +38,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
       error,
       label,
       name,
+      step = 'any',
       type: initialType,
       ...rest
     } = props
@@ -74,7 +76,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
             id={name}
             name={name}
             ref={forwardedRef}
-            step={type === 'number' ? 'any' : undefined}
+            step={type === 'number' ? step : undefined}
             type={type}
             {...rest}
           />

--- a/ui/src/design-system/components/input/input.tsx
+++ b/ui/src/design-system/components/input/input.tsx
@@ -21,6 +21,7 @@ interface InputProps {
   error?: string
   label: string
   name: string
+  noArrows?: boolean
   placeholder?: string
   step?: number
   type?: 'text' | 'number' | 'password'
@@ -38,6 +39,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
       error,
       label,
       name,
+      noArrows,
       step = 'any',
       type: initialType,
       ...rest
@@ -71,6 +73,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
             autoComplete="on"
             className={classNames(styles.input, {
               [styles.password]: initialType === 'password',
+              [styles.noArrows]: noArrows,
             })}
             disabled={disabled}
             id={name}

--- a/ui/src/design-system/map/editable-map/editable-map.tsx
+++ b/ui/src/design-system/map/editable-map/editable-map.tsx
@@ -44,7 +44,7 @@ export const EditableMap = ({
       maxBounds={MAX_BOUNDS}
       minZoom={MIN_ZOOM}
       ref={mapRef}
-      scrollWheelZoom={false}
+      scrollWheelZoom
       zoom={DEFAULT_ZOOM}
     >
       <MapContent

--- a/ui/src/design-system/map/minimap-control.tsx
+++ b/ui/src/design-system/map/minimap-control.tsx
@@ -78,7 +78,7 @@ export const MinimapControl = () => {
           doubleClickZoom={false}
           dragging={false}
           maxBounds={MAX_BOUNDS}
-          scrollWheelZoom={false}
+          scrollWheelZoom
           style={MINIMAP_STYLE}
           zoom={MINIMAP_ZOOM}
           zoomControl={false}

--- a/ui/src/design-system/map/multi-marker-map/multi-marker-map.tsx
+++ b/ui/src/design-system/map/multi-marker-map/multi-marker-map.tsx
@@ -57,7 +57,7 @@ export const MultiMarkerMap = ({
       maxBounds={MAX_BOUNDS}
       minZoom={MIN_ZOOM}
       ref={mapRef}
-      scrollWheelZoom={false}
+      scrollWheelZoom
     >
       <TileLayer attribution={ATTRIBUTION} url={TILE_LAYER_URL} />
       {markers.map((marker, index) => (

--- a/ui/src/pages/deployment-details/deployment-details-form/section-location/section-location.tsx
+++ b/ui/src/pages/deployment-details/deployment-details-form/section-location/section-location.tsx
@@ -93,6 +93,7 @@ export const SectionLocation = ({
             config={config}
             type="number"
             step={1 / 100000}
+            noArrows
             onBlur={(e) => {
               const lat = _.toNumber(e.currentTarget.value)
               setValue('latitude', lat)
@@ -105,6 +106,7 @@ export const SectionLocation = ({
             config={config}
             type="number"
             step={1 / 100000}
+            noArrows
             onBlur={(e) => {
               const lng = _.toNumber(e.currentTarget.value)
               setValue('longitude', lng)

--- a/ui/src/pages/deployment-details/deployment-details-form/section-location/section-location.tsx
+++ b/ui/src/pages/deployment-details/deployment-details-form/section-location/section-location.tsx
@@ -92,6 +92,7 @@ export const SectionLocation = ({
             control={control}
             config={config}
             type="number"
+            step={1 / 100000}
             onBlur={(e) => {
               const lat = _.toNumber(e.currentTarget.value)
               setValue('latitude', lat)
@@ -103,6 +104,7 @@ export const SectionLocation = ({
             control={control}
             config={config}
             type="number"
+            step={1 / 100000}
             onBlur={(e) => {
               const lng = _.toNumber(e.currentTarget.value)
               setValue('longitude', lng)

--- a/ui/src/pages/deployment-details/deployment-details-info.tsx
+++ b/ui/src/pages/deployment-details/deployment-details-info.tsx
@@ -71,11 +71,11 @@ export const DeploymentDetailsInfo = ({
           <FormRow>
             <InputValue
               label={translate(STRING.FIELD_LABEL_LATITUDE)}
-              value={deployment.latitude}
+              value={`${deployment.latitude}`}
             />
             <InputValue
               label={translate(STRING.FIELD_LABEL_LONGITUDE)}
-              value={deployment.longitude}
+              value={`${deployment.longitude}`}
             />
           </FormRow>
         </FormSection>


### PR DESCRIPTION
Small deployment location tweaks after feedback from Lars!

### Summary of changes:
- Update step size for deployment latitude/longitude fields from 1 -> 0.00001.
- Hide step arrows for deployment latitude/longitude fields. Most common use case here is probably to copy/paste values, not use arrows. However, stepping will still be possible to do from keyboard, no need to override the browser default behaviour here.
- Enable scroll wheel zoom in all maps
- Fix missing decimals in latitude/longitude display values (see screenshots)

Before:
<img width="377" alt="Skärmavbild 2024-06-12 kl  16 23 33" src="https://github.com/RolnickLab/ami-platform/assets/11680517/1274463a-af3d-4269-92e8-38393bdc0df8">

After:
<img width="381" alt="Skärmavbild 2024-06-12 kl  16 18 09" src="https://github.com/RolnickLab/ami-platform/assets/11680517/0563683a-8e03-4d8e-a0d9-002ef5f41526">