### PR TITLE
Pass auth header when calling cancel job

### DIFF
--- a/ui/src/data-services/hooks/jobs/useCancelJob.ts
+++ b/ui/src/data-services/hooks/jobs/useCancelJob.ts
@@ -12,6 +12,7 @@ export const useCancelJob = () => {
     mutationFn: (id: string) =>
       axios.post<{ id: number }>(
         `${API_URL}/${API_ROUTES.JOBS}/${id}/cancel/`,
+        undefined,
         {
           headers: getAuthHeader(user),
         }


### PR DESCRIPTION
We did not pass auth header correctly when cancelling a job, meaning users were not able to cancel jobs. Fixes #373!?