### PR TITLE
Fix deployment date labels

### DIFF
--- a/ui/src/data-services/models/deployment.ts
+++ b/ui/src/data-services/models/deployment.ts
@@ -61,14 +61,18 @@ export class Deployment {
     return this._deployment.taxa_count
   }
 
-  get firstDateLabel(): string {
-    return getFormatedDateString({
-      date: new Date(this._deployment.first_date),
-    })
+  get firstDateLabel(): string | undefined {
+    return this.numImages
+      ? getFormatedDateString({
+          date: new Date(this._deployment.first_date),
+        })
+      : undefined
   }
 
-  get lastDateLabel(): string {
-    return getFormatedDateString({ date: new Date(this._deployment.last_date) })
+  get lastDateLabel(): string | undefined {
+    return this.numImages
+      ? getFormatedDateString({ date: new Date(this._deployment.last_date) })
+      : undefined
   }
 
   get dataSourceDetails(): {


### PR DESCRIPTION
If deployment has no captures, we show no start or end labels. Workaround for https://github.com/RolnickLab/ami-platform/issues/461 to avoid confusions in upcoming launch, but feel free to do a proper fix BE side when there is time :)