### PR TITLE
Tweak occurrence duration label

### DIFF
--- a/ui/src/data-services/models/occurrence.ts
+++ b/ui/src/data-services/models/occurrence.ts
@@ -93,8 +93,10 @@ export class Occurrence {
       : undefined
   }
 
-  get durationLabel(): string {
-    return this._occurrence.duration_label
+  get durationLabel(): string | undefined {
+    return this._occurrence.duration_label?.length
+      ? this._occurrence.duration_label
+      : undefined
   }
 
   get displayName(): string {

--- a/ui/src/design-system/components/table/basic-table-cell/basic-table-cell.tsx
+++ b/ui/src/design-system/components/table/basic-table-cell/basic-table-cell.tsx
@@ -30,7 +30,7 @@ export const BasicTableCell = ({
       })}
       style={{ textAlign, ...style }}
     >
-      {label && <span className={styles.label}>{label}</span>}
+      {label ? <span className={styles.label}>{label}</span> : null}
       {details &&
         details.map((detail, index) => (
           <span key={index} className={styles.details}>

--- a/ui/src/pages/occurrences/occurrence-columns.tsx
+++ b/ui/src/pages/occurrences/occurrence-columns.tsx
@@ -147,7 +147,9 @@ export const columns: (projectId: string) => TableColumn<Occurrence>[] = (
     name: translate(STRING.FIELD_LABEL_DURATION),
     sortField: 'duration',
     renderCell: (item: Occurrence) => (
-      <BasicTableCell value={item.durationLabel} />
+      <BasicTableCell
+        value={item.durationLabel ?? translate(STRING.VALUE_NOT_AVAILABLE)}
+      />
     ),
   },
   {


### PR DESCRIPTION
Just a small tweak for occurrence duration label. For the one detection case (which for now is the main case), the empty label looked a bit strange in the modal.

**Before:**

![Skärmavbild 2024-08-05 kl  10 17 58](https://github.com/user-attachments/assets/50979ebf-614b-4728-ab03-4efa470bca54)

**After:**

![Skärmavbild 2024-08-05 kl  10 15 58](https://github.com/user-attachments/assets/5988e40f-9b55-489c-8354-c4377f197c11)
