### PR TITLE
Adjust deployment map info

### DIFF
--- a/ui/src/pages/overview/deployments-map/deployments-map-popup-content.tsx
+++ b/ui/src/pages/overview/deployments-map/deployments-map-popup-content.tsx
@@ -1,5 +1,6 @@
 import { Deployment } from 'data-services/models/deployment'
-import { Link, useParams } from 'react-router-dom'
+import { InfoBlock } from 'design-system/components/info-block/info-block'
+import { useParams } from 'react-router-dom'
 import { APP_ROUTES } from 'utils/constants'
 import { STRING, translate } from 'utils/language'
 
@@ -11,31 +12,21 @@ export const DeploymentsMapPopupContent = ({
   const { projectId } = useParams()
 
   return (
-    <>
-      <p>
-        <Link
-          to={APP_ROUTES.DEPLOYMENT_DETAILS({
+    <InfoBlock
+      fields={[
+        {
+          label: translate(STRING.FIELD_LABEL_DEPLOYMENT),
+          value: deployment.name,
+          to: APP_ROUTES.DEPLOYMENT_DETAILS({
             projectId: projectId as string,
             deploymentId: deployment.id,
-          })}
-        >
-          <span>{deployment.name}</span>
-        </Link>
-      </p>
-      <p>
-        <span>
-          {translate(STRING.FIELD_LABEL_SESSIONS)}: {deployment.numEvents}
-        </span>
-        <br />
-        <span>
-          {translate(STRING.FIELD_LABEL_CAPTURES)}: {deployment.numImages}
-        </span>
-        <br />
-        <span>
-          {translate(STRING.FIELD_LABEL_OCCURRENCES)}:{' '}
-          {deployment.numOccurrences}
-        </span>
-      </p>
-    </>
+          }),
+        },
+        {
+          label: translate(STRING.FIELD_LABEL_SESSIONS),
+          value: deployment.numEvents,
+        },
+      ]}
+    />
   )
 }


### PR DESCRIPTION
### Summary
On the deployment map popover, some fields were missing values. This is because we get the deployment data from the project details response in this view and it seems a bit less detailed (only name, location and and session count is returned). Before we have more info, let's skip those fields.

Also, as part of this small PR, we are updating the popover content to better match rest of app.

### Screenshots
Before:
<img width="394" alt="Skärmavbild 2024-08-06 kl  11 37 19" src="https://github.com/user-attachments/assets/950f9e95-3cf0-41b3-9c7f-d5473df48f59">

After:
<img width="392" alt="Skärmavbild 2024-08-06 kl  11 35 53" src="https://github.com/user-attachments/assets/32857fe7-f3cf-4869-8ebf-ff04806c04d9">
