### PR TITLE
Make all checkboxes controlled

### DIFF
--- a/ui/src/design-system/components/checkbox/checkbox.stories.tsx
+++ b/ui/src/design-system/components/checkbox/checkbox.stories.tsx
@@ -10,9 +10,9 @@ export default {
 
 export const Default: Meta = {
   args: {
+    checked: true,
     label: 'Lorem ipsum',
     id: 'checkbox',
     theme: CheckboxTheme.Default,
-    defaultChecked: true,
   },
 }

--- a/ui/src/design-system/components/checkbox/checkbox.tsx
+++ b/ui/src/design-system/components/checkbox/checkbox.tsx
@@ -11,8 +11,7 @@ export enum CheckboxTheme {
 }
 
 interface CheckboxProps {
-  checked?: boolean | 'indeterminate'
-  defaultChecked?: boolean
+  checked: boolean | 'indeterminate'
   id?: string
   label?: string
   theme?: CheckboxTheme
@@ -21,7 +20,6 @@ interface CheckboxProps {
 
 export const Checkbox = ({
   checked,
-  defaultChecked,
   id,
   label,
   theme = CheckboxTheme.Default,
@@ -33,7 +31,6 @@ export const Checkbox = ({
       className={classNames(styles.checkboxRoot, {
         [styles.neutral]: theme === CheckboxTheme.Neutral,
       })}
-      defaultChecked={defaultChecked}
       id={id}
       onCheckedChange={onCheckedChange}
     >

--- a/ui/src/design-system/components/table/column-settings/column-settings.tsx
+++ b/ui/src/design-system/components/table/column-settings/column-settings.tsx
@@ -35,6 +35,7 @@ export const ColumnSettings = ({
           {columns.map((column) => (
             <Checkbox
               key={column.id}
+              checked={columnSettings[column.id]}
               id={column.id}
               label={column.name}
               onCheckedChange={(checked) => {
@@ -43,7 +44,6 @@ export const ColumnSettings = ({
                   [column.id]: checked,
                 })
               }}
-              defaultChecked={columnSettings[column.id]}
             />
           ))}
         </div>

--- a/ui/src/pages/job-details/job-details-form/job-details-form.tsx
+++ b/ui/src/pages/job-details/job-details-form/job-details-form.tsx
@@ -144,9 +144,9 @@ export const JobDetailsForm = ({
               config={config.pipeline}
               render={({ field }) => (
                 <Checkbox
+                  checked={field.value ?? false}
                   id={field.name}
                   label={config[field.name].label}
-                  defaultChecked={field.value}
                   onCheckedChange={field.onChange}
                 />
               )}


### PR DESCRIPTION
In the bulk action PR where we introduced the checkbox "indeterminate" state and started to move towards a fully controlled checkbox, meaning we rely on the state to always be controlled by the parent component. In this PR we update the component API to require a `checked` prop. Visually, this will fix issues with missing icons that sometimes occurred.

Before:

<img width="211" alt="Skärmavbild 2024-08-06 kl  12 11 09" src="https://github.com/user-attachments/assets/ed4f2ea9-6e4b-47ae-98dc-d7f75f1432af">

After:

<img width="207" alt="Skärmavbild 2024-08-06 kl  12 11 42" src="https://github.com/user-attachments/assets/962e62f0-46f9-4847-9c51-f4c9f5bae236">
