### PR TITLE
Tweak tick config for plots

### DIFF
--- a/ui/src/design-system/components/plot/plot.tsx
+++ b/ui/src/design-system/components/plot/plot.tsx
@@ -82,7 +82,6 @@ const Plot = ({
           tickvals: data.tickvals,
           ticktext: data.ticktext,
           tickformat: 'd',
-          dtick: 1,
           automargin: true,
           ...(showRangeSlider
             ? {


### PR DESCRIPTION
The `dtick` prop was previously set to `1` to avoid decimal values on the x-asis for some plots, but this turned out to have bad consequences for other plots. Skipping this prop for now, I think it must be set conditionally.

Before:
<img width="379" alt="Skärmavbild 2024-08-06 kl  12 17 29" src="https://github.com/user-attachments/assets/7df64777-7290-467d-9ea0-cbe9cd538cef">

After:
<img width="382" alt="Skärmavbild 2024-08-06 kl  12 21 09" src="https://github.com/user-attachments/assets/46fb3a72-0f15-46c7-9918-1606c7084ea8">
