### PR TITLE
Format numbers based on browser locale

### DIFF
--- a/ui/src/design-system/components/info-block/info-block.tsx
+++ b/ui/src/design-system/components/info-block/info-block.tsx
@@ -17,6 +17,7 @@ export const InfoBlock = ({ fields }: { fields: Field[] }) => (
         field.value === undefined
           ? translate(STRING.VALUE_NOT_AVAILABLE)
           : field.value
+      const valueLabel = _.isNumber(value) ? value.toLocaleString() : value
 
       return (
         <p className={styles.field} key={index}>
@@ -28,13 +29,11 @@ export const InfoBlock = ({ fields }: { fields: Field[] }) => (
                   [styles.bubble]: _.isNumber(value),
                 })}
               >
-                {value}
+                {valueLabel}
               </span>
             </Link>
           ) : (
-            <span className={styles.fieldValue}>
-              {value ?? translate(STRING.VALUE_NOT_AVAILABLE)}
-            </span>
+            <span className={styles.fieldValue}>{valueLabel}</span>
           )}
         </p>
       )

--- a/ui/src/design-system/components/input/input.tsx
+++ b/ui/src/design-system/components/input/input.tsx
@@ -111,19 +111,19 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
 
 export const InputValue = ({
   label,
-  value: _value,
+  value,
   to,
 }: {
   label: string
   value?: string | number
   to?: string
 }) => {
-  const value =
-    _value === undefined || _value === ''
+  const valueLabel =
+    value === undefined || value === ''
       ? translate(STRING.VALUE_NOT_AVAILABLE)
-      : _.isNumber(_value)
-      ? _value.toLocaleString()
-      : _value
+      : _.isNumber(value)
+      ? value.toLocaleString()
+      : value
 
   return (
     <InputContent label={label}>
@@ -132,7 +132,7 @@ export const InputValue = ({
           {value}
         </Link>
       ) : (
-        <span className={styles.value}>{value ?? STRING}</span>
+        <span className={styles.value}>{valueLabel}</span>
       )}
     </InputContent>
   )

--- a/ui/src/design-system/components/navigation/navigation-bar.tsx
+++ b/ui/src/design-system/components/navigation/navigation-bar.tsx
@@ -66,7 +66,9 @@ export const NavigationBar = ({
                       />
                     )}
                     {item.count !== undefined && (
-                      <span className={styles.itemCount}>{item.count}</span>
+                      <span className={styles.itemCount}>
+                        {item.count.toLocaleString()}
+                      </span>
                     )}
                   </div>
                   <span className={styles.itemTitle}>{item.title}</span>

--- a/ui/src/design-system/components/table/basic-table-cell/basic-table-cell.tsx
+++ b/ui/src/design-system/components/table/basic-table-cell/basic-table-cell.tsx
@@ -20,7 +20,7 @@ export const BasicTableCell = ({
   style = {},
 }: BasicTableCellProps) => {
   const textAlign = _.isNumber(value) ? TextAlign.Right : TextAlign.Left
-  const label = _.isNumber(value) ? value.toLocaleString() : value
+  const valueLabel = _.isNumber(value) ? value.toLocaleString() : value
 
   return (
     <div
@@ -30,7 +30,7 @@ export const BasicTableCell = ({
       })}
       style={{ textAlign, ...style }}
     >
-      {label ? <span className={styles.label}>{label}</span> : null}
+      {valueLabel ? <span className={styles.label}>{valueLabel}</span> : null}
       {details &&
         details.map((detail, index) => (
           <span key={index} className={styles.details}>


### PR DESCRIPTION
**We are now doing this for all following scenarios:**
- In navigation bar
- In table columns
- For info blocks
- For read only form values

**Examples:**

<img width="645" alt="Skärmavbild 2024-08-07 kl  09 23 53" src="https://github.com/user-attachments/assets/3127ba8b-4c6b-4bad-a64a-783cce2eef74">
<img width="1264" alt="Skärmavbild 2024-08-07 kl  09 24 13" src="https://github.com/user-attachments/assets/df3ccb52-700f-4ba1-9e7c-2a5f07b6d05b">
<img width="522" alt="Skärmavbild 2024-08-07 kl  09 26 42" src="https://github.com/user-attachments/assets/2329c290-d1a9-4212-b806-898a860b3e3e">
<img width="765" alt="Skärmavbild 2024-08-07 kl  09 27 11" src="https://github.com/user-attachments/assets/4afb326f-7990-4f75-bf0a-be62ad7ef110">
