### PR TITLE
Fixes to the session captures timeline data

### DIFF
--- a/ami/main/api/serializers.py
+++ b/ami/main/api/serializers.py
@@ -1217,6 +1217,7 @@ class EventTimelineIntervalSerializer(serializers.Serializer):
     start = serializers.DateTimeField()
     end = serializers.DateTimeField()
     first_capture = EventTimelineSourceImageSerializer(allow_null=True)
+    top_capture = EventTimelineSourceImageSerializer(allow_null=True)
     captures_count = serializers.IntegerField()
     detections_count = serializers.IntegerField()
 

--- a/ami/main/api/serializers.py
+++ b/ami/main/api/serializers.py
@@ -1220,6 +1220,7 @@ class EventTimelineIntervalSerializer(serializers.Serializer):
     top_capture = EventTimelineSourceImageSerializer(allow_null=True)
     captures_count = serializers.IntegerField()
     detections_count = serializers.IntegerField()
+    detections_avg = serializers.IntegerField()
 
 
 class EventTimelineMetaSerializer(serializers.Serializer):

--- a/ami/main/api/views.py
+++ b/ami/main/api/views.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+from statistics import mode
 
 from django.contrib.postgres.search import TrigramSimilarity
 from django.core import exceptions
@@ -283,6 +284,7 @@ class EventViewSet(DefaultViewSet):
                 "top_capture": None,
                 "captures_count": 0,
                 "detections_count": 0,
+                "detection_counts": [],
             }
 
             while image_index < len(source_images) and source_images[image_index]["timestamp"] <= interval_end:
@@ -291,7 +293,15 @@ class EventViewSet(DefaultViewSet):
                     interval_data["first_capture"] = SourceImage(pk=image["id"])
                 interval_data["captures_count"] += 1
                 interval_data["detections_count"] += image["detections_count"] or 0
+                interval_data["detection_counts"] += [image["detections_count"]]
+                if image["detections_count"] >= max(interval_data["detection_counts"]):
+                    interval_data["top_capture"] = SourceImage(pk=image["id"])
                 image_index += 1
+
+            # Set a meaningful average detection count to display for the interval
+            # Remove zero values and calculate the mode
+            interval_data["detection_counts"] = [x for x in interval_data["detection_counts"] if x > 0]
+            interval_data["detections_avg"] = mode(interval_data["detection_counts"] or [0])
 
             timeline.append(interval_data)
             current_time = interval_end

--- a/ami/main/api/views.py
+++ b/ami/main/api/views.py
@@ -280,6 +280,7 @@ class EventViewSet(DefaultViewSet):
                 "start": current_time,
                 "end": interval_end,
                 "first_capture": None,
+                "top_capture": None,
                 "captures_count": 0,
                 "detections_count": 0,
             }

--- a/ui/src/data-services/models/timeline-tick.ts
+++ b/ui/src/data-services/models/timeline-tick.ts
@@ -70,6 +70,6 @@ export class TimelineTick {
       },
     })
 
-    return `${timespanString}<br>Captures: ${this.numCaptures}<br>Avg. Detections: ${this.avgDetections}`
+    return `${timespanString}<br>Captures: ${this.numCaptures}<br>Avg. detections: ${this.avgDetections}`
   }
 }

--- a/ui/src/data-services/models/timeline-tick.ts
+++ b/ui/src/data-services/models/timeline-tick.ts
@@ -11,6 +11,7 @@ export type ServerTimelineTick = {
   } | null
   captures_count: number
   detections_count: number
+  detections_avg: number
 }
 
 export class TimelineTick {
@@ -26,6 +27,10 @@ export class TimelineTick {
 
   get numDetections(): number {
     return this._timelineTick.detections_count ?? 0
+  }
+
+  get avgDetections(): number {
+    return this._timelineTick.detections_avg ?? 0
   }
 
   get numCaptures(): number {
@@ -65,6 +70,6 @@ export class TimelineTick {
       },
     })
 
-    return `${timespanString}<br>Captures: ${this.numCaptures}<br>Detections: ${this.numDetections}`
+    return `${timespanString}<br>Captures: ${this.numCaptures}<br>Avg. Detections: ${this.avgDetections}`
   }
 }

--- a/ui/src/data-services/models/timeline-tick.ts
+++ b/ui/src/data-services/models/timeline-tick.ts
@@ -6,6 +6,9 @@ export type ServerTimelineTick = {
   first_capture: {
     id: number
   } | null
+  top_capture: {
+    id: number
+  } | null
   captures_count: number
   detections_count: number
 }
@@ -39,6 +42,18 @@ export class TimelineTick {
     }
 
     return `${this._timelineTick.first_capture.id}`
+  }
+
+  get topCaptureId(): string | undefined {
+    if (!this._timelineTick.top_capture) {
+      return undefined
+    }
+
+    return `${this._timelineTick.top_capture.id}`
+  }
+
+  get representativeCaptureId(): string | undefined {
+    return this.topCaptureId ?? this.firstCaptureId
   }
 
   get tooltip(): string {

--- a/ui/src/pages/session-details/playback/activity-plot/activity-plot.tsx
+++ b/ui/src/pages/session-details/playback/activity-plot/activity-plot.tsx
@@ -41,14 +41,14 @@ export const ActivityPlot = ({
             },
             {
               x: timeline.map((timelineTick) => timelineTick.startDate),
-              y: timeline.map((timelineTick) => timelineTick.numDetections),
+              y: timeline.map((timelineTick) => timelineTick.avgDetections),
               text: timeline.map((timelineTick) => timelineTick.tooltip),
               hovertemplate: '%{text}<extra></extra>',
               fill: 'tozeroy',
               type: 'scatter',
               mode: 'lines',
               line: { color: lineColorDetections, width: 1 },
-              name: 'Detections',
+              name: 'Avg. Detections',
             },
           ]}
           layout={{

--- a/ui/src/pages/session-details/playback/activity-plot/activity-plot.tsx
+++ b/ui/src/pages/session-details/playback/activity-plot/activity-plot.tsx
@@ -68,7 +68,7 @@ export const ActivityPlot = ({
               type: 'scatter',
               mode: 'lines',
               line: { color: lineColorDetections, width: 1 },
-              name: 'Avg. Detections',
+              name: 'Avg. detections',
               yaxis: 'y2',
             },
           ]}
@@ -84,6 +84,7 @@ export const ActivityPlot = ({
               t: 0,
               pad: 0,
             },
+            // y-axis for captures
             yaxis: {
               showgrid: false,
               showticklabels: false,
@@ -93,13 +94,14 @@ export const ActivityPlot = ({
               range: [yAxisMin, yAxisMax],
               side: 'left',
             },
+            // y-axis for detections
             yaxis2: {
               showgrid: false,
               showticklabels: false,
               zeroline: false,
               rangemode: 'nonnegative',
               fixedrange: true,
-              range: [0, session.detectionsMaxCount ?? yAxisMax],
+              range: [0, Math.max(session.detectionsMaxCount ?? 0, 1)], // Ensure a minimum range of 1
               side: 'right',
               overlaying: 'y',
             },

--- a/ui/src/pages/session-details/playback/activity-plot/activity-plot.tsx
+++ b/ui/src/pages/session-details/playback/activity-plot/activity-plot.tsx
@@ -99,7 +99,7 @@ export const ActivityPlot = ({
               zeroline: false,
               rangemode: 'nonnegative',
               fixedrange: true,
-              range: [0, session.detectionsMaxCount],
+              range: [0, session.detectionsMaxCount ?? yAxisMax],
               side: 'right',
               overlaying: 'y',
             },

--- a/ui/src/pages/session-details/playback/activity-plot/activity-plot.tsx
+++ b/ui/src/pages/session-details/playback/activity-plot/activity-plot.tsx
@@ -95,8 +95,8 @@ export const ActivityPlot = ({
           onClick={(data) => {
             const timelineTickIndex = data.points[0].pointIndex
             const timelineTick = timeline[timelineTickIndex]
-            if (timelineTick?.firstCaptureId) {
-              setActiveCaptureId(timelineTick.firstCaptureId)
+            if (timelineTick?.representativeCaptureId) {
+              setActiveCaptureId(timelineTick.representativeCaptureId)
             }
           }}
         />

--- a/ui/src/pages/session-details/playback/activity-plot/activity-plot.tsx
+++ b/ui/src/pages/session-details/playback/activity-plot/activity-plot.tsx
@@ -38,6 +38,7 @@ export const ActivityPlot = ({
               mode: 'lines',
               line: { color: lineColorCaptures, width: 1 },
               name: 'Captures',
+              yaxis: 'y', // This refers to the first `yaxis` property
             },
             {
               x: timeline.map((timelineTick) => timelineTick.startDate),
@@ -49,6 +50,7 @@ export const ActivityPlot = ({
               mode: 'lines',
               line: { color: lineColorDetections, width: 1 },
               name: 'Avg. Detections',
+              yaxis: 'y2', // This refers to the `yaxis2` property
             },
           ]}
           layout={{
@@ -64,11 +66,24 @@ export const ActivityPlot = ({
               pad: 0,
             },
             yaxis: {
+              // y-axis for captures
               showgrid: false,
               showticklabels: false,
               zeroline: false,
               rangemode: 'nonnegative',
               fixedrange: true,
+              side: 'left',
+            },
+            yaxis2: {
+              // y-axis for detections
+              showgrid: false,
+              showticklabels: false,
+              zeroline: false,
+              rangemode: 'nonnegative',
+              fixedrange: true,
+              range: [0, session.detectionsMaxCount],
+              side: 'right',
+              overlaying: 'y',
             },
             xaxis: {
               showline: true,

--- a/ui/src/pages/session-details/playback/activity-plot/activity-plot.tsx
+++ b/ui/src/pages/session-details/playback/activity-plot/activity-plot.tsx
@@ -10,6 +10,7 @@ const lineColorDetections = '#5f8ac6'
 const textColor = '#222426'
 const tooltipBgColor = '#ffffff'
 const tooltipBorderColor = '#222426'
+const gridLineColor = '#f36399'
 
 export const ActivityPlot = ({
   session,
@@ -43,7 +44,9 @@ export const ActivityPlot = ({
           style={{ display: 'block' }}
           data={[
             {
-              x: timeline.map((timelineTick) => timelineTick.startDate),
+              x: timeline.map(
+                (timelineTick) => new Date(timelineTick.startDate)
+              ),
               y: timeline.map((timelineTick) => timelineTick.numCaptures),
               text: timeline.map((timelineTick) => timelineTick.tooltip),
               hovertemplate: '%{text}<extra></extra>',
@@ -52,10 +55,12 @@ export const ActivityPlot = ({
               mode: 'lines',
               line: { color: lineColorCaptures, width: 1 },
               name: 'Captures',
-              yaxis: 'y', // This refers to the first `yaxis` property
+              yaxis: 'y',
             },
             {
-              x: timeline.map((timelineTick) => timelineTick.startDate),
+              x: timeline.map(
+                (timelineTick) => new Date(timelineTick.startDate)
+              ),
               y: timeline.map((timelineTick) => timelineTick.avgDetections),
               text: timeline.map((timelineTick) => timelineTick.tooltip),
               hovertemplate: '%{text}<extra></extra>',
@@ -99,12 +104,16 @@ export const ActivityPlot = ({
               overlaying: 'y',
             },
             xaxis: {
-              showline: true,
-              showgrid: false,
+              showline: false,
+              showgrid: true,
+              griddash: 'dot',
+              gridwidth: 1,
+              gridcolor: gridLineColor,
               showticklabels: false,
               zeroline: false,
               fixedrange: true,
-              range: [session.startDate, session.endDate],
+              range: [new Date(session.startDate), new Date(session.endDate)],
+              dtick: 3600000, // milliseconds in an hour
             },
             hoverlabel: {
               bgcolor: tooltipBgColor,

--- a/ui/src/pages/session-details/playback/activity-plot/activity-plot.tsx
+++ b/ui/src/pages/session-details/playback/activity-plot/activity-plot.tsx
@@ -22,6 +22,20 @@ export const ActivityPlot = ({
 }) => {
   const containerRef = useRef(null)
   const width = useDynamicPlotWidth(containerRef)
+
+  // Calculate the average number of captures
+  const avgCaptures =
+    timeline.reduce((sum, tick) => sum + tick.numCaptures, 0) / timeline.length
+
+  // Calculate the maximum deviation from the average
+  const maxDeviation = Math.max(
+    ...timeline.map((tick) => Math.abs(tick.numCaptures - avgCaptures))
+  )
+
+  // Set the y-axis range to be centered around the average
+  const yAxisMin = Math.max(0, avgCaptures - maxDeviation)
+  const yAxisMax = avgCaptures + maxDeviation
+
   return (
     <div style={{ margin: '0 14px -10px' }}>
       <div ref={containerRef}>
@@ -50,7 +64,7 @@ export const ActivityPlot = ({
               mode: 'lines',
               line: { color: lineColorDetections, width: 1 },
               name: 'Avg. Detections',
-              yaxis: 'y2', // This refers to the `yaxis2` property
+              yaxis: 'y2',
             },
           ]}
           layout={{
@@ -66,16 +80,15 @@ export const ActivityPlot = ({
               pad: 0,
             },
             yaxis: {
-              // y-axis for captures
               showgrid: false,
               showticklabels: false,
               zeroline: false,
               rangemode: 'nonnegative',
               fixedrange: true,
+              range: [yAxisMin, yAxisMax],
               side: 'left',
             },
             yaxis2: {
-              // y-axis for detections
               showgrid: false,
               showticklabels: false,
               zeroline: false,

--- a/ui/src/pages/session-details/playback/capture-navigation/capture-navigation.tsx
+++ b/ui/src/pages/session-details/playback/capture-navigation/capture-navigation.tsx
@@ -69,7 +69,7 @@ export const CaptureNavigation = ({
       />
       {totalCaptures && (
         <span>
-          {currentIndex} / {totalCaptures}
+          {currentIndex?.toLocaleString()} / {totalCaptures.toLocaleString()}
         </span>
       )}
       <IconButton


### PR DESCRIPTION
- Fixes the issue where clicking on a "spike" (interval) activates the _first_ capture in the interval, which may have no detections and feels confusing. Now when clicking on a spike the capture with the most detections is activated instead of the first capture in the interval.
- Fixes the num captures displayed per interval. Now uses the mode average of detections from captures within the interval (ignoring zeros). Before it was a sum of all detections in the interval, which felt misleading. 
- Fixes the issue where capture ticks were not visible if the number of detections is high. Now the captures Y axis has its own range (centered around its average) that is separate from the range of the detections y axis.
- Added vertical grid lines on the hour marks! Just a quick way to do it until we can add labels in #482 

Before:
![image](https://github.com/user-attachments/assets/d3a741bd-d6a7-4ee6-8cf6-bad5af6bfe62)
After:
![image](https://github.com/user-attachments/assets/7081c963-10f8-4ded-8c63-8842eb18f6b6)

Before:
![image](https://github.com/user-attachments/assets/1f1a6dc0-8ca3-49fe-bb70-1c6c8c7f7069)
After:
![image](https://github.com/user-attachments/assets/45a98e6d-2d9b-45cd-a319-a9aa99a0b601)

