### PR TITLE
Load main view and detail view in parallel

### DIFF
--- a/ui/src/pages/deployment-details/deployment-details-dialog.tsx
+++ b/ui/src/pages/deployment-details/deployment-details-dialog.tsx
@@ -58,13 +58,13 @@ const DeploymentDetailsDialogContent = ({
 }) => {
   const [isEditing, setIsEditing] = useState(false)
   const { updateDeployment, isLoading, error } = useUpdateDeployment(
-    deployment?.id
+    deployment.id
   )
 
   useEffect(() => {
     // Reset to view mode when a new deployment is selected
     setIsEditing(false)
-  }, [deployment?.id])
+  }, [deployment.id])
 
   return (
     <>

--- a/ui/src/pages/deployments/deployments.tsx
+++ b/ui/src/pages/deployments/deployments.tsx
@@ -42,13 +42,13 @@ export const Deployments = () => {
       </PageHeader>
       <Table
         items={sortedItems}
-        isLoading={isLoading}
+        isLoading={!id && isLoading}
         columns={columns(projectId as string)}
         sortable
         sortSettings={sort}
         onSortSettingsChange={setSort}
       />
-      {!isLoading && id ? <DeploymentDetailsDialog id={id} /> : null}
+      {id ? <DeploymentDetailsDialog id={id} /> : null}
     </>
   )
 }

--- a/ui/src/pages/jobs/jobs.tsx
+++ b/ui/src/pages/jobs/jobs.tsx
@@ -50,7 +50,7 @@ export const Jobs = () => {
       </PageHeader>
       <Table
         items={jobs}
-        isLoading={isLoading}
+        isLoading={!id && isLoading}
         columns={columns(projectId as string)}
         sortable
         sortSettings={sort}
@@ -65,7 +65,7 @@ export const Jobs = () => {
           />
         ) : null}
       </PageFooter>
-      {!isLoading && id ? <JobDetailsDialog id={id} /> : null}
+      {id ? <JobDetailsDialog id={id} /> : null}
     </>
   )
 }

--- a/ui/src/pages/occurrences/occurrences.tsx
+++ b/ui/src/pages/occurrences/occurrences.tsx
@@ -100,7 +100,7 @@ export const Occurrences = () => {
       {selectedView === 'table' && (
         <Table
           items={occurrences}
-          isLoading={isLoading}
+          isLoading={!id && isLoading}
           columns={columns(
             projectId as string,
             selectedItems.length === 0
@@ -115,7 +115,10 @@ export const Occurrences = () => {
       )}
       {selectedView === 'gallery' && (
         <div className={styles.galleryContent}>
-          <OccurrenceGallery occurrences={occurrences} isLoading={isLoading} />
+          <OccurrenceGallery
+            occurrences={occurrences}
+            isLoading={!id && isLoading}
+          />
         </div>
       )}
       <PageFooter>
@@ -141,7 +144,7 @@ export const Occurrences = () => {
           />
         ) : null}
       </PageFooter>
-      {!isLoading && id ? <OccurrenceDetailsDialog id={id} /> : null}
+      {id ? <OccurrenceDetailsDialog id={id} /> : null}
     </>
   )
 }

--- a/ui/src/pages/species-details/species-details.tsx
+++ b/ui/src/pages/species-details/species-details.tsx
@@ -21,7 +21,7 @@ export const SpeciesDetails = ({ species }: { species: Species }) => {
   const blueprintItems = useMemo(
     () =>
       species.occurrences.length
-        ? species?.occurrences
+        ? species.occurrences
             .map((id) => species.getOccurrenceInfo(id))
             .filter((item): item is BlueprintItem => !!item)
             .map((item) => ({

--- a/ui/src/pages/species/species.tsx
+++ b/ui/src/pages/species/species.tsx
@@ -71,7 +71,7 @@ export const Species = () => {
       {selectedView === 'table' && (
         <Table
           items={species}
-          isLoading={isLoading}
+          isLoading={!id && isLoading}
           columns={columns(projectId as string)}
           sortable
           sortSettings={sort}
@@ -80,7 +80,7 @@ export const Species = () => {
       )}
       {selectedView === 'gallery' && (
         <div className={styles.galleryContent}>
-          <SpeciesGallery species={species} isLoading={isLoading} />
+          <SpeciesGallery species={species} isLoading={!id && isLoading} />
         </div>
       )}
       <PageFooter>
@@ -92,7 +92,7 @@ export const Species = () => {
           />
         ) : null}
       </PageFooter>
-      {!isLoading && id ? <SpeciesDetailsDialog id={id} /> : null}
+      {id ? <SpeciesDetailsDialog id={id} /> : null}
     </>
   )
 }


### PR DESCRIPTION
### Summary
Instead of loading detail view after main view has been loaded, we now load them in parallel. We do this for jobs, deployments, occurrences and species. This fixes #466.

### Loading state examples
Main view loading, detail view loading:
![Skärmavbild 2024-08-16 kl  10 54 54](https://github.com/user-attachments/assets/a97b364e-0bd6-419b-9866-af0aff791a5e)

Main view loading, detail view loaded:
![Skärmavbild 2024-08-16 kl  10 54 24](https://github.com/user-attachments/assets/0ea2a4b3-8d9e-4ef7-a3a5-38c64c7a86bc)

Main view loaded, detail view loading:
![Skärmavbild 2024-08-16 kl  10 55 50](https://github.com/user-attachments/assets/6bb65c2c-2a82-4c66-b5f2-d98ddf47486e)