### PR TITLE
Update password reset confirm URL

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -338,7 +338,7 @@ CSRF_TRUSTED_ORIGINS = env.list(
 # User authentication and registration via REST API endpoints
 # https://djoser.readthedocs.io/en/latest/settings.html
 DJOSER = {
-    "PASSWORD_RESET_CONFIRM_URL": "#/password/reset/confirm/{uid}/{token}",
+    "PASSWORD_RESET_CONFIRM_URL": "/auth/reset-password-confirm?uid={uid}&token={token}",
     "USERNAME_RESET_CONFIRM_URL": "#/username/reset/confirm/{uid}/{token}",
     # "ACTIVATION_URL": "#/activate/{uid}/{token}",
     "SEND_CONFIRMATION_EMAIL": True,


### PR DESCRIPTION
To match the app updates in #526. 

Looked like this in email before, which is why I skipped the "#":
<img width="591" alt="Skärmavbild 2024-08-20 kl  19 58 33" src="https://github.com/user-attachments/assets/4627726b-6706-44b2-a4a8-f7660fc7891f">

Is it possible to make base URL dynamic based on where the FE request is coming from?
