### PR TITLE
Fix pagination bar appearance on info dialog open

### DIFF
--- a/ui/src/components/info-dialog/info-dialog.tsx
+++ b/ui/src/components/info-dialog/info-dialog.tsx
@@ -3,16 +3,16 @@ import { Button, ButtonTheme } from 'design-system/components/button/button'
 import * as Dialog from 'design-system/components/dialog/dialog'
 import { STRING, translate } from 'utils/language'
 import styles from './info-dialog.module.scss'
-import { useActivePage } from './useActivePage'
+import { useActiveInfoPage } from './useActiveInfoPage'
 
 export const InfoDialog = ({ name, slug }: { name: string; slug: string }) => {
-  const { activePage, setActivePage } = useActivePage()
+  const { activeInfoPage, setActiveInfoPage } = useActiveInfoPage()
   const { page, isLoading, error } = usePageDetails(slug)
 
   return (
     <Dialog.Root
-      open={activePage === slug}
-      onOpenChange={(open) => setActivePage(open ? slug : undefined)}
+      open={activeInfoPage === slug}
+      onOpenChange={(open) => setActiveInfoPage(open ? slug : undefined)}
     >
       <Dialog.Trigger>
         <Button label={name} theme={ButtonTheme.Plain} />

--- a/ui/src/components/info-dialog/useActiveInfoPage.ts
+++ b/ui/src/components/info-dialog/useActiveInfoPage.ts
@@ -1,13 +1,13 @@
 import { useSearchParams } from 'react-router-dom'
 
-const SEARCH_PARAM_KEY = 'page'
+const SEARCH_PARAM_KEY = 'info-page'
 
-export const useActivePage = () => {
+export const useActiveInfoPage = () => {
   const [searchParams, setSearchParams] = useSearchParams()
 
-  const activePage = searchParams.get(SEARCH_PARAM_KEY) ?? undefined
+  const activeInfoPage = searchParams.get(SEARCH_PARAM_KEY) ?? undefined
 
-  const setActivePage = (pageSlug?: string) => {
+  const setActiveInfoPage = (pageSlug?: string) => {
     searchParams.delete(SEARCH_PARAM_KEY)
     if (pageSlug?.length) {
       searchParams.set(SEARCH_PARAM_KEY, pageSlug)
@@ -15,5 +15,5 @@ export const useActivePage = () => {
     setSearchParams(searchParams)
   }
 
-  return { activePage, setActivePage }
+  return { activeInfoPage, setActiveInfoPage }
 }


### PR DESCRIPTION
Fixes #528 

Funny bug, the reason was clashing search param keys (both info page dialog and the pagination bar were checking the key "page"). Fixing by renaming "page" -> "info-page" for the info page dialog.