### PR TITLE
Disable sign up

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -352,6 +352,9 @@ DJOSER = {
         "user": "ami.users.api.serializers.UserSerializer",
         "current_user": "ami.users.api.serializers.CurrentUserSerializer",
     },
+    "PERMISSIONS": {
+        "user_create": ["rest_framework.permissions.IsAdminUser"],
+    },
 }
 
 # By Default swagger ui is available only to admin user(s). You can change permission classes to change that

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -14,7 +14,6 @@ import { Auth } from 'pages/auth/auth'
 import { Login } from 'pages/auth/login'
 import { ResetPassword } from 'pages/auth/reset-password'
 import { ResetPasswordConfirm } from 'pages/auth/reset-password-confirm'
-import { SignUp } from 'pages/auth/sign-up'
 import { CollectionDetails } from 'pages/collection-details/collection-details'
 import { Deployments } from 'pages/deployments/deployments'
 import { Jobs } from 'pages/jobs/jobs'
@@ -65,7 +64,6 @@ export const App = () => (
         />
         <Route path="auth" element={<AuthContainer />}>
           <Route path="login" element={<Login />} />
-          <Route path="sign-up" element={<SignUp />} />
           <Route path="reset-password" element={<ResetPassword />} />
           <Route
             path="reset-password-confirm"

--- a/ui/src/components/header/header.tsx
+++ b/ui/src/components/header/header.tsx
@@ -51,11 +51,6 @@ export const Header = () => {
         ) : (
           <>
             <Button
-              label={translate(STRING.SIGN_UP)}
-              theme={ButtonTheme.Plain}
-              onClick={() => navigate(APP_ROUTES.SIGN_UP)}
-            />
-            <Button
               label={translate(STRING.LOGIN)}
               theme={ButtonTheme.Plain}
               onClick={() =>

--- a/ui/src/pages/auth/login.tsx
+++ b/ui/src/pages/auth/login.tsx
@@ -79,6 +79,8 @@ export const Login = () => {
             {errorMessage}
           </p>
         )}
+      </form>
+      <div className={styles.outro}>
         <p className={styles.text}>
           {translate(STRING.FORGOT_PASSWORD)}{' '}
           <Link
@@ -88,12 +90,7 @@ export const Login = () => {
             {translate(STRING.RESET)}
           </Link>
         </p>
-      </form>
-      <div className={styles.outro}>
-        <p className={styles.text}>
-          {translate(STRING.MESSAGE_NO_ACCOUNT_YET)}{' '}
-          <Link to={APP_ROUTES.SIGN_UP}>{translate(STRING.SIGN_UP)}</Link>
-        </p>
+        {/* TODO: Add link to join waitlist */}
         <p className={classNames(styles.text, styles.divider)}>
           {translate(STRING.OR).toUpperCase()}
         </p>


### PR DESCRIPTION
Hide sign up from UI and make user registration disabled from API as well (make endpoint only possible to call for admin users). When we have the waitlist, we can add a link to it from the login page.