### PR TITLE
Only call endpoint /me if user is logged in

### DIFF
--- a/ui/src/data-services/hooks/auth/tests/useUserInfo.test.ts
+++ b/ui/src/data-services/hooks/auth/tests/useUserInfo.test.ts
@@ -17,6 +17,7 @@ describe('useUserInfo', () => {
     axios.get.mockImplementation(() =>
       Promise.resolve({ data: { id: 1, email: 'user@insectai.org' } })
     )
+    localStorage.setItem(AUTH_TOKEN_STORAGE_KEY, 'example-token') // Simulate logged in user
 
     // Run
     const { result } = renderHook(() => useUserInfo(), { wrapper: AppMock })
@@ -39,7 +40,7 @@ describe('useUserInfo', () => {
 
     // Run
     const { result } = renderHook(() => useUserInfo(), { wrapper: AppMock })
-    await waitFor(() => expect(result.current.error).not.toBeNull())
+    await waitFor(() => expect(result.current.userInfo).toBeUndefined())
 
     // Check
     expect(localStorage.getItem(AUTH_TOKEN_STORAGE_KEY)).toBeNull()

--- a/ui/src/data-services/hooks/auth/useAuthorizedQuery.ts
+++ b/ui/src/data-services/hooks/auth/useAuthorizedQuery.ts
@@ -4,6 +4,7 @@ import { getAuthHeader } from 'data-services/utils'
 import { useUser } from 'utils/user/userContext'
 
 export const useAuthorizedQuery = <T>({
+  enabled,
   onError,
   queryKey = [],
   refetchInterval,
@@ -11,6 +12,7 @@ export const useAuthorizedQuery = <T>({
   staleTime,
   url,
 }: {
+  enabled?: boolean
   onError?: (error: unknown) => void
   queryKey?: QueryKey
   refetchInterval?: number
@@ -19,8 +21,8 @@ export const useAuthorizedQuery = <T>({
   url: string
 }) => {
   const { user } = useUser()
-
   const { data, isLoading, isFetching, isSuccess, error } = useQuery({
+    enabled,
     onError,
     queryKey,
     queryFn: () =>

--- a/ui/src/data-services/hooks/auth/useUserInfo.ts
+++ b/ui/src/data-services/hooks/auth/useUserInfo.ts
@@ -10,6 +10,7 @@ const REFETCH_INTERVAL = 10000 // Refetch every 10 second
 export const useUserInfo = () => {
   const { user, clearToken } = useUser()
   const { data, isLoading, error } = useAuthorizedQuery<ServerUserInfo>({
+    enabled: user.loggedIn,
     queryKey: [API_ROUTES.ME],
     url: `${API_URL}/${API_ROUTES.ME}/`,
     refetchInterval: REFETCH_INTERVAL,


### PR DESCRIPTION
No need to poll this endpoint if we already know the user is not logged in.