### PR TITLE
Add UI to docker compose stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,17 +6,29 @@ Platform for processing and reviewing images from automated insect monitoring st
 
 ## Quick Start
 
-The platform uses Docker Compose to run all backend services. To run all services locally, install Docker and run the following command:
+The platform uses Docker Compose to run all services locally for development. Install Docker Desktop and run the following command:
 
     $ docker compose up
 
-Explore the API
+- Web UI: http://localhost:4000
+- API Browser: http://localhost:8000/api/v2/
+- Django admin: http://localhost:8000/admin/
+- OpenAPI / Swagger Docs: http://localhost:8000/api/v2/docs/
 
-- Rest Framework: http://localhost:8000/api/v2/
-- Access the Django admin: http://localhost:8000/admin/
-- OpenAPI / Swagger: http://localhost:8000/api/v2/docs/
+## Development
 
-Install and run the frontend:
+### Frontend
+
+#### Dependencies
+
+- [Node.js](https://nodejs.org/en/download/)
+- [Yarn](https://yarnpkg.com/getting-started/install)
+
+#### Configuration
+
+By default this will try to connect to http://localhost:8000 for the backend API. Use the env var `API_PROXY_TARGET` to change this. You can create multiple `.env` files in the `ui/` directory for different environments or configurations. For example, use `yarn start --mode staging` to load `.env.staging` and point the `API_PROXY_TARGET` to a remote backend.
+
+#### Installation
 
 ```bash
 # Enter into the ui directory
@@ -32,21 +44,6 @@ yarn start
 ```
 
 Visit http://localhost:3000/
-
-_TODO! Make a pre-built frontend available in the Docker compose stack._
-
-## Development
-
-### Frontend
-
-#### Dependencies
-
-- [Node.js](https://nodejs.org/en/download/)
-- [Yarn](https://yarnpkg.com/getting-started/install)
-
-#### Configuration
-
-By default this will try to connect to http://localhost:8000 for the backend API. Use the env var `API_PROXY_TARGET` to change this. You can create multiple `.env` files in the `ui/` directory for different environments or configurations. For example, use `yarn start --mode staging` to load `.env.staging` and point the `API_PROXY_TARGET` to a remote backend.
 
 ### Backend
 

--- a/compose/local/ui/Dockerfile
+++ b/compose/local/ui/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:18
+WORKDIR /app
+COPY package.json yarn.lock ./
+RUN yarn install
+COPY . .
+RUN ["git", "config", "--global", "--add", "safe.directory", "/app"]
+ENV BROWSER=none
+CMD ["yarn", "start", "--host", "0.0.0.0" , "--port", "4000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,23 @@ services:
     env_file:
       - ./.envs/.local/.postgres
 
+  ui:
+    image: ami_local_ui
+    build:
+      context: ./ui
+      dockerfile: ../compose/local/ui/Dockerfile
+    ports:
+      - "4000:4000"
+    volumes:
+      - ./.git:/app/.git:ro
+      - ./ui:/app:z
+      - /app/node_modules
+    depends_on:
+      - django
+    environment:
+      - CHOKIDAR_USEPOLLING=true
+      - API_PROXY_TARGET=http://django:8000
+
   docs:
     image: ami_local_docs
     build:


### PR DESCRIPTION
This enables viewing & developing the entire app locally with just `docker compose up`

The frontend is available at http://localhost:4000 

The one service missing from the stack is a default ML backend for processing.