### PR TITLE
Make sure cover images are not overflowing frame

### DIFF
--- a/ui/src/pages/overview/overview.module.scss
+++ b/ui/src/pages/overview/overview.module.scss
@@ -21,19 +21,20 @@
 }
 
 .aboutImage {
-  background-color: $color-generic-white;
   position: relative;
   display: flex;
   align-items: center;
   justify-content: center;
+  background-color: rgba($color: $color-primary-2-50, $alpha: 0.5);
+  border-right: 1px solid $color-neutral-100;
 
   img {
     position: absolute;
-    top: 0;
-    right: 0;
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
+    top: 32px;
+    right: 32px;
+    width: calc(100% - 64px);
+    height: calc(100% - 64px);
+    object-fit: contain;
   }
 }
 


### PR DESCRIPTION
In practice, seems most cover images are logos. It looks a bit strange when they overflow the container. Here comes small tweaks to keep all cover images inside the container.

Before:
<img width="1440" alt="Skärmavbild 2024-09-04 kl  13 31 31" src="https://github.com/user-attachments/assets/42bc48e4-bd5c-4d03-a9f5-377674401924">

After:
<img width="1440" alt="Skärmavbild 2024-09-04 kl  13 38 36" src="https://github.com/user-attachments/assets/3573569b-a264-494c-ad2d-c9b729fbbfb9">
