### PR TITLE
Fix yarn dependencies for fresh installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ By default this will try to connect to http://localhost:8000 for the backend API
 
 #### Installation
 
+Note: if you installed the ui using Docker first (as instructed in the quick-start) then your local `node_modules/` directory will be owned by root. Change the permissions with:
+`sudo chown -R ${UID}:${UID} ui/node_modules`. The version of Node on your host machine must match that of the Docker container (which will be the case if you follow the `nvm` instructions below.)
+
 ```bash
 # Enter into the ui directory
 cd ui

--- a/compose/local/ui/Dockerfile
+++ b/compose/local/ui/Dockerfile
@@ -1,3 +1,4 @@
+# Node version should always match the version in `ui/.nvmrc`
 FROM node:18
 WORKDIR /app
 USER node

--- a/compose/local/ui/Dockerfile
+++ b/compose/local/ui/Dockerfile
@@ -1,5 +1,6 @@
 FROM node:18
 WORKDIR /app
+USER node
 COPY package.json yarn.lock ./
 RUN yarn install
 COPY . .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,8 +52,8 @@ services:
       - "4000:4000"
     volumes:
       - ./.git:/app/.git:ro
-      - ./ui:/app:z
-      - /app/node_modules
+      - ./ui:/app
+      - ./ui/node_modules:/app/node_modules
     depends_on:
       - django
     environment:

--- a/ui/.nvmrc
+++ b/ui/.nvmrc
@@ -1,1 +1,3 @@
 v18.12.0
+
+# This should always match the version in `local/ui/Dockerfile`

--- a/ui/package.json
+++ b/ui/package.json
@@ -93,9 +93,5 @@
     "ts-jest": "^29.1.1",
     "vite-plugin-eslint": "^1.8.1",
     "vite-plugin-svgr": "^4.1.0"
-  },
-  "resolutions": {
-    "semver@npm:2 || 3 || 4 || 5": "6.3.1",
-    "semver@npm:^5.6.0": "6.3.1"
   }
 }

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -15234,7 +15234,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:6.3.1, semver@npm:^6.0.0, semver@npm:^6.3.0, semver@npm:^6.3.1":
+"semver@npm:2 || 3 || 4 || 5, semver@npm:^5.6.0":
+  version: 5.7.2
+  resolution: "semver@npm:5.7.2"
+  bin:
+    semver: bin/semver
+  checksum: e4cf10f86f168db772ae95d86ba65b3fd6c5967c94d97c708ccb463b778c2ee53b914cd7167620950fc07faf5a564e6efe903836639e512a1aa15fbc9667fa25
+  languageName: node
+  linkType: hard
+
+"semver@npm:^6.0.0, semver@npm:^6.3.0, semver@npm:^6.3.1":
   version: 6.3.1
   resolution: "semver@npm:6.3.1"
   bin:


### PR DESCRIPTION
Vanessa and I both encountered this error when installing the UI on a fresh system

```
https://registry.yarnpkg.com/2%20%7C%7C%203%20%7C%7C%204%20%7C%7C%205: Not found
```

The issue seems to be related to how the `semver` dependency was defined.

This also updates the Docker container to share node_modules with the host, so you only have to install packages once. The Node versions should stay in-sync as long as both Dockerfile & .nvmrc stay up-to-date.