### PR TITLE
Show license info for images

### DIFF
--- a/ui/src/components/blueprint-collection/blueprint-collection.tsx
+++ b/ui/src/components/blueprint-collection/blueprint-collection.tsx
@@ -3,6 +3,7 @@ import { Icon, IconType } from 'design-system/components/icon/icon'
 import { useState } from 'react'
 import { Link } from 'react-router-dom'
 import styles from './blueprint-collection.module.scss'
+import { LicenseInfo } from 'components/license-info/license-info'
 
 export interface BlueprintItem {
   id: string
@@ -19,6 +20,7 @@ export const BlueprintCollection = ({ items }: { items: BlueprintItem[] }) => (
       [styles.empty]: items.length === 0,
     })}
   >
+    <LicenseInfo style={{ textAlign: 'right' }} />
     {items.map((item) =>
       item.to ? (
         <Link key={item.id} to={item.to} className={styles.blueprintItem}>

--- a/ui/src/components/license-info/license-info.module.scss
+++ b/ui/src/components/license-info/license-info.module.scss
@@ -1,0 +1,13 @@
+@import 'src/design-system/variables/colors.scss';
+@import 'src/design-system/variables/typography.scss';
+
+.text {
+  @include paragraph-small();
+  color: $color-neutral-300;
+  margin: 0;
+
+  a {
+    font-weight: 600;
+    color: $color-primary-1-600;
+  }
+}

--- a/ui/src/components/license-info/license-info.tsx
+++ b/ui/src/components/license-info/license-info.tsx
@@ -1,0 +1,18 @@
+import { CSSProperties } from 'react'
+import styles from './license-info.module.scss'
+
+const LINK = 'https://creativecommons.org/licenses/by-nc/4.0/legalcode'
+
+interface LicenseInfoProps {
+  style?: CSSProperties
+}
+
+export const LicenseInfo = ({ style }: LicenseInfoProps) => {
+  // TODO: Check licence given the current project
+
+  return (
+    <p className={styles.text} style={style}>
+      These images are licensed under <a href={LINK}>CC BY-NC 4.0</a>
+    </p>
+  )
+}

--- a/ui/src/design-system/components/image-carousel/image-carousel.tsx
+++ b/ui/src/design-system/components/image-carousel/image-carousel.tsx
@@ -11,6 +11,7 @@ import { getTotalLabel } from 'utils/numberFormats'
 import styles from './image-carousel.module.scss'
 import { CarouselTheme } from './types'
 import { getImageBoxStyles, getPlaceholderStyles } from './utils'
+import { LicenseInfo } from 'components/license-info/license-info'
 
 interface ImageCarouselProps {
   autoPlay?: boolean
@@ -18,26 +19,34 @@ interface ImageCarouselProps {
     src: string
     alt?: string
   }[]
-  total?: number
+  showLicenseInfo?: boolean
   size?: {
     width: string | number
     ratio: number
   }
   theme?: CarouselTheme
+  total?: number
   to?: string
 }
 
 export const ImageCarousel = ({
   autoPlay,
   images,
-  total,
+  showLicenseInfo,
   size,
   theme = CarouselTheme.Default,
+  total,
   to,
 }: ImageCarouselProps) => {
   if (images.length <= 1) {
     return (
-      <BasicImageCarousel image={images[0]} size={size} theme={theme} to={to} />
+      <BasicImageCarousel
+        image={images[0]}
+        showLicenseInfo={showLicenseInfo}
+        size={size}
+        theme={theme}
+        to={to}
+      />
     )
   }
 
@@ -45,9 +54,10 @@ export const ImageCarousel = ({
     <MultiImageCarousel
       autoPlay={autoPlay}
       images={images}
-      total={total}
+      showLicenseInfo={showLicenseInfo}
       size={size}
       theme={theme}
+      total={total}
       to={to}
     />
   )
@@ -55,6 +65,7 @@ export const ImageCarousel = ({
 
 const BasicImageCarousel = ({
   image,
+  showLicenseInfo,
   size,
   theme,
   to,
@@ -63,6 +74,7 @@ const BasicImageCarousel = ({
     src: string
     alt?: string
   }
+  showLicenseInfo?: boolean
   size?: {
     width: string | number
     ratio: number
@@ -92,6 +104,7 @@ const BasicImageCarousel = ({
         </div>
       </div>
     </ConditionalLink>
+    {showLicenseInfo && <LicenseInfo style={{ marginTop: '32px' }} />}
   </div>
 )
 
@@ -100,9 +113,10 @@ const DURATION = 10000 // Change image every 10 second
 const MultiImageCarousel = ({
   autoPlay,
   images,
-  total,
+  showLicenseInfo,
   size,
   theme,
+  total,
   to,
 }: ImageCarouselProps) => {
   const [paused, setPaused] = useState(false)
@@ -223,6 +237,7 @@ const MultiImageCarousel = ({
       <span className={styles.info}>
         {slideIndex + 1} / {totalLabel}
       </span>
+      {showLicenseInfo && <LicenseInfo style={{ marginTop: '32px' }} />}
     </div>
   )
 }

--- a/ui/src/pages/deployment-details/deployment-details-info.tsx
+++ b/ui/src/pages/deployment-details/deployment-details-info.tsx
@@ -106,6 +106,7 @@ export const DeploymentDetailsInfo = ({
               <div className={styles.section}>
                 <ImageCarousel
                   images={deployment.exampleCaptures}
+                  showLicenseInfo
                   size={{ width: '100%', ratio: 16 / 9 }}
                   total={deployment.numImages}
                 />

--- a/ui/src/pages/session-details/playback/playback.module.scss
+++ b/ui/src/pages/session-details/playback/playback.module.scss
@@ -47,6 +47,13 @@
   margin-bottom: 16px;
 }
 
+.licenseInfoWrapper {
+  flex: 1;
+  p a {
+    color: $color-generic-white;
+  }
+}
+
 .bottomBar {
   grid-column: span 2;
   background-color: $color-neutral-700;
@@ -73,6 +80,8 @@
 
   .captureNavigationWrapper {
     margin-bottom: 32px;
+    gap: 16px;
+    flex-direction: column-reverse;
     justify-content: center;
   }
 }

--- a/ui/src/pages/session-details/playback/playback.tsx
+++ b/ui/src/pages/session-details/playback/playback.tsx
@@ -15,6 +15,7 @@ import styles from './playback.module.scss'
 import { SessionCapturesSlider } from './session-captures-slider/session-captures-slider'
 import { ThresholdSlider } from './threshold-slider/threshold-slider'
 import { useActiveCaptureId } from './useActiveCapture'
+import { LicenseInfo } from 'components/license-info/license-info'
 
 export const Playback = ({ session }: { session: SessionDetails }) => {
   const {
@@ -73,6 +74,9 @@ export const Playback = ({ session }: { session: SessionDetails }) => {
             activeCapture={activeCapture}
             setActiveCaptureId={setActiveCaptureId}
           />
+          <div className={styles.licenseInfoWrapper}>
+            <LicenseInfo style={{ textAlign: 'right' }} />
+          </div>
         </div>
         <div>
           <ActivityPlot


### PR DESCRIPTION
We show this under deployment sample images, in session details view, in occurrence details view and in species details view. Later, this license might differ depending on project settings.

Example:

<img width="1440" alt="Skärmavbild 2024-09-10 kl  17 49 36" src="https://github.com/user-attachments/assets/c0abae6b-10f1-4743-9f2d-9c969495416c">
