### PR TITLE
Frontend workarounds for demo

### DIFF
--- a/ui/src/data-services/models/session.ts
+++ b/ui/src/data-services/models/session.ts
@@ -71,6 +71,13 @@ export class Session {
   }
 
   get numSpecies(): number | undefined {
+    // Workaround for taxa count being 0 when occurrences count > 0
+    if (this.numOccurrences) {
+      if (this._event.taxa_count === 0) {
+        return undefined
+      }
+    }
+
     return this._event.taxa_count
   }
 

--- a/ui/src/pages/pipeline-details/pipeline-details-dialog.tsx
+++ b/ui/src/pages/pipeline-details/pipeline-details-dialog.tsx
@@ -94,7 +94,7 @@ const PipelineDetailsContent = ({
               />
             </FormRow>
           </FormSection>
-          {pipeline.stages.length > 0 && (
+          {pipeline.stages.length > 1 && (
             <FormSection title={translate(STRING.STAGES)}>
               <PipelineStages pipeline={pipeline} />
             </FormSection>

--- a/ui/src/pages/pipeline-details/pipeline-details-dialog.tsx
+++ b/ui/src/pages/pipeline-details/pipeline-details-dialog.tsx
@@ -94,7 +94,7 @@ const PipelineDetailsContent = ({
               />
             </FormRow>
           </FormSection>
-          {pipeline.stages.length > 1 && (
+          {pipeline.stages.length > 0 && (
             <FormSection title={translate(STRING.STAGES)}>
               <PipelineStages pipeline={pipeline} />
             </FormSection>

--- a/ui/src/pages/session-details/session-info/session-info.tsx
+++ b/ui/src/pages/session-details/session-info/session-info.tsx
@@ -46,14 +46,18 @@ export const SessionInfo = ({ session }: { session: Session }) => {
         filters: { event: session.id },
       }),
     },
-    {
-      label: translate(STRING.FIELD_LABEL_SPECIES),
-      value: session.numSpecies,
-      to: getAppRoute({
-        to: APP_ROUTES.SPECIES({ projectId: projectId as string }),
-        filters: { occurrences__event: session.id },
-      }),
-    },
+    ...(session.numSpecies !== undefined
+      ? [
+          {
+            label: translate(STRING.FIELD_LABEL_SPECIES),
+            value: session.numSpecies,
+            to: getAppRoute({
+              to: APP_ROUTES.SPECIES({ projectId: projectId as string }),
+              filters: { occurrences__event: session.id },
+            }),
+          },
+        ]
+      : []),
   ]
 
   return (

--- a/ui/src/pages/sessions/sessions.tsx
+++ b/ui/src/pages/sessions/sessions.tsx
@@ -27,10 +27,13 @@ export const Sessions = () => {
     images: true,
     duration: true,
     captures: true,
-    occurrences: false,
+    occurrences: true,
     species: true,
   })
-  const { sort, setSort } = useSort({ field: 'start', order: 'desc' })
+  const { sort, setSort } = useSort({
+    field: 'occurrences_count',
+    order: 'desc',
+  })
   const { pagination, setPage } = usePagination()
   const { filters } = useFilters()
   const { sessions, total, isLoading, isFetching, error } = useSessions({

--- a/ui/src/utils/useNavItems.ts
+++ b/ui/src/utils/useNavItems.ts
@@ -4,6 +4,7 @@ import { useMemo } from 'react'
 import { matchPath, useLocation, useParams } from 'react-router-dom'
 import { APP_ROUTES } from './constants'
 import { STRING, translate } from './language'
+import { useUser } from './user/userContext'
 
 interface NavigationItem {
   id: string
@@ -18,6 +19,9 @@ export const useNavItems = () => {
   const location = useLocation()
   const { projectId } = useParams()
   const { status } = useStatus(projectId)
+  const {
+    user: { loggedIn },
+  } = useUser()
 
   const navItems: NavigationItem[] = useMemo(
     () => [
@@ -28,16 +32,20 @@ export const useNavItems = () => {
         path: APP_ROUTES.PROJECT_DETAILS({ projectId: projectId as string }),
         matchPath: APP_ROUTES.PROJECT_DETAILS({ projectId: ':projectId' }),
       },
-      {
-        id: 'jobs',
-        title: translate(STRING.NAV_ITEM_JOBS),
-        icon: IconType.BatchId,
-        path: APP_ROUTES.JOBS({ projectId: projectId as string }),
-        matchPath: APP_ROUTES.JOB_DETAILS({
-          projectId: ':projectId',
-          jobId: '*',
-        }),
-      },
+      ...(loggedIn
+        ? [
+            {
+              id: 'jobs',
+              title: translate(STRING.NAV_ITEM_JOBS),
+              icon: IconType.BatchId,
+              path: APP_ROUTES.JOBS({ projectId: projectId as string }),
+              matchPath: APP_ROUTES.JOB_DETAILS({
+                projectId: ':projectId',
+                jobId: '*',
+              }),
+            },
+          ]
+        : []),
       {
         id: 'deployments',
         title: translate(STRING.NAV_ITEM_DEPLOYMENTS),
@@ -83,7 +91,7 @@ export const useNavItems = () => {
         }),
       },
     ],
-    [status, projectId]
+    [status, projectId, loggedIn]
   )
 
   const activeNavItem =


### PR DESCRIPTION
Including some frontend workarounds while we work on some backend improvements:
- Hide job tab if user is not logged in
- Set default sort to occurrences count in session tab
- Hide wrong species count in session details