### PR TITLE
Session details improvements

### DIFF
--- a/ui/src/data-services/models/timeline-tick.ts
+++ b/ui/src/data-services/models/timeline-tick.ts
@@ -1,5 +1,3 @@
-import { getCompactTimespanString } from 'utils/date/getCompactTimespanString/getCompactTimespanString'
-
 export type ServerTimelineTick = {
   start: string
   end: string
@@ -59,17 +57,5 @@ export class TimelineTick {
 
   get representativeCaptureId(): string | undefined {
     return this.topCaptureId ?? this.firstCaptureId
-  }
-
-  get tooltip(): string {
-    const timespanString = getCompactTimespanString({
-      date1: this.startDate,
-      date2: this.endDate,
-      options: {
-        second: true,
-      },
-    })
-
-    return `${timespanString}<br>Captures: ${this.numCaptures}<br>Avg. detections: ${this.avgDetections}`
   }
 }

--- a/ui/src/design-system/components/plot/plot.tsx
+++ b/ui/src/design-system/components/plot/plot.tsx
@@ -81,7 +81,6 @@ const Plot = ({
           zeroline: false,
           tickvals: data.tickvals,
           ticktext: data.ticktext,
-          tickformat: 'd',
           automargin: true,
           ...(showRangeSlider
             ? {

--- a/ui/src/pages/session-details/playback/activity-plot/activity-plot.tsx
+++ b/ui/src/pages/session-details/playback/activity-plot/activity-plot.tsx
@@ -4,6 +4,7 @@ import { useRef } from 'react'
 import Plot from 'react-plotly.js'
 import { getCompactTimespanString } from 'utils/date/getCompactTimespanString/getCompactTimespanString'
 import { useDynamicPlotWidth } from './useDynamicPlotWidth'
+import { findClosestCaptureId } from '../session-captures-slider/utils'
 
 const fontFamily = 'Mazzard, sans-serif'
 const lineColorCaptures = '#4E4F57'
@@ -144,8 +145,17 @@ export const ActivityPlot = ({
           onClick={(data) => {
             const timelineTickIndex = data.points[0].pointIndex
             const timelineTick = timeline[timelineTickIndex]
-            if (timelineTick?.representativeCaptureId) {
-              setActiveCaptureId(timelineTick.representativeCaptureId)
+
+            if (!timelineTick) {
+              return
+            }
+
+            const captureId =
+              timelineTick.representativeCaptureId ??
+              findClosestCaptureId(timeline, timelineTick.startDate)
+
+            if (captureId) {
+              setActiveCaptureId(captureId)
             }
           }}
         />

--- a/ui/src/pages/session-details/playback/activity-plot/activity-plot.tsx
+++ b/ui/src/pages/session-details/playback/activity-plot/activity-plot.tsx
@@ -2,15 +2,16 @@ import { SessionDetails } from 'data-services/models/session-details'
 import { TimelineTick } from 'data-services/models/timeline-tick'
 import { useRef } from 'react'
 import Plot from 'react-plotly.js'
+import { getCompactTimespanString } from 'utils/date/getCompactTimespanString/getCompactTimespanString'
 import { useDynamicPlotWidth } from './useDynamicPlotWidth'
 
 const fontFamily = 'Mazzard, sans-serif'
 const lineColorCaptures = '#4E4F57'
 const lineColorDetections = '#5F8AC6'
+const spikeColor = '#FFFFFF'
 const textColor = '#303137'
-const tooltipBgColor = '#ffffff'
+const tooltipBgColor = '#FFFFFF'
 const tooltipBorderColor = '#303137'
-const gridLineColor = '#4E4F57'
 
 export const ActivityPlot = ({
   session,
@@ -48,8 +49,7 @@ export const ActivityPlot = ({
                 (timelineTick) => new Date(timelineTick.startDate)
               ),
               y: timeline.map((timelineTick) => timelineTick.numCaptures),
-              text: timeline.map((timelineTick) => timelineTick.tooltip),
-              hovertemplate: '%{text}<extra></extra>',
+              hovertemplate: 'Captures: %{y}<extra></extra>',
               fill: 'tozeroy',
               type: 'scatter',
               mode: 'lines',
@@ -62,8 +62,7 @@ export const ActivityPlot = ({
                 (timelineTick) => new Date(timelineTick.startDate)
               ),
               y: timeline.map((timelineTick) => timelineTick.avgDetections),
-              text: timeline.map((timelineTick) => timelineTick.tooltip),
-              hovertemplate: '%{text}<extra></extra>',
+              hovertemplate: 'Avg. detections: %{y}<extra></extra>',
               fill: 'tozeroy',
               type: 'scatter',
               mode: 'lines',
@@ -84,6 +83,7 @@ export const ActivityPlot = ({
               t: 0,
               pad: 0,
             },
+            hovermode: 'x unified',
             // y-axis for captures
             yaxis: {
               showgrid: false,
@@ -106,16 +106,26 @@ export const ActivityPlot = ({
               overlaying: 'y',
             },
             xaxis: {
-              showline: false,
-              showgrid: true,
-              griddash: 'dot',
-              gridwidth: 1,
-              gridcolor: gridLineColor,
-              showticklabels: false,
-              zeroline: false,
               fixedrange: true,
               range: [new Date(session.startDate), new Date(session.endDate)],
-              dtick: 3600000, // milliseconds in an hour
+              showgrid: false,
+              showline: false,
+              showticklabels: false,
+              spikecolor: spikeColor,
+              spikethickness: -2,
+              ticktext: timeline.map((timelineTick) =>
+                getCompactTimespanString({
+                  date1: timelineTick.startDate,
+                  date2: timelineTick.endDate,
+                  options: {
+                    second: true,
+                  },
+                })
+              ),
+              tickvals: timeline.map(
+                (timelineTick) => new Date(timelineTick.startDate)
+              ),
+              zeroline: false,
             },
             hoverlabel: {
               bgcolor: tooltipBgColor,

--- a/ui/src/pages/session-details/session-details.tsx
+++ b/ui/src/pages/session-details/session-details.tsx
@@ -60,16 +60,22 @@ export const SessionDetails = () => {
             <SessionInfo session={session} />
           </div>
         </Box>
-        {session.summaryData.map((summary, index) => (
-          <Box key={index}>
-            <Plot
-              title={summary.title}
-              data={summary.data}
-              orientation={summary.orientation}
-              type={summary.type}
-            />
-          </Box>
-        ))}
+        {session.summaryData.map((summary, index) => {
+          if (summary.data.x.length <= 1) {
+            return null
+          }
+
+          return (
+            <Box key={index}>
+              <Plot
+                title={summary.title}
+                data={summary.data}
+                orientation={summary.orientation}
+                type={summary.type}
+              />
+            </Box>
+          )
+        })}
       </PlotGrid>
     </div>
   )


### PR DESCRIPTION
**Activity chart improvements:**
- Change hover mode to "x unified"
- Show color indicators on hover
- Skip vertical lines to indicate hours for now (seems not fully clear to users what this line is)

**Session details tweaks:**
- Update plot x axis tick format. This will change [0, 1, 1, 2, 2] -> [0, 0.5, 1, 2, 2.5]. Even if we are dealing with integers for counts, I think the later version looks more correct. I would of course prefer [0,1,2], but setting a fixed tick distance is causing problems for plots with lots of ticks. We could probably try some smarter solution here when there is time.
- Hide plots with 0-1 data points (to avoid empty plots and strange looking plots with just one bar).