### PR TITLE
Small screen adjustments

### DIFF
--- a/ui/src/components/blueprint-collection/blueprint-collection.module.scss
+++ b/ui/src/components/blueprint-collection/blueprint-collection.module.scss
@@ -19,7 +19,7 @@
 
 .licenseInfoContent {
   padding: 20px;
-  text-align: right;
+  text-align: center;
 }
 
 .blueprintContent {

--- a/ui/src/components/form/layout/layout.module.scss
+++ b/ui/src/components/form/layout/layout.module.scss
@@ -80,7 +80,7 @@
     }
   }
 
-  .sectionTitle {
+  .sectionHeader {
     margin: 0 0 16px;
   }
 

--- a/ui/src/design-system/components/dialog/dialog.module.scss
+++ b/ui/src/design-system/components/dialog/dialog.module.scss
@@ -119,7 +119,7 @@ $dialog-padding-medium: 32px;
 }
 
 @media only screen and (max-width: $small-screen-breakpoint) {
-  .dialog {
+  .dialog:not(.compact) {
     width: 100%;
     height: 100vh;
     height: 100dvh;
@@ -129,14 +129,9 @@ $dialog-padding-medium: 32px;
     border-radius: 0;
     border: none;
 
-    &.compact {
-      width: auto;
-      max-width: calc(100% - 32px);
+    .dialogContent {
+      height: 100%;
     }
-  }
-
-  .dialogContent {
-    height: 100%;
   }
 
   .dialogHeader {

--- a/ui/src/design-system/components/plot/plot.tsx
+++ b/ui/src/design-system/components/plot/plot.tsx
@@ -69,6 +69,7 @@ const Plot = ({
         },
         yaxis: {
           color: textColor,
+          fixedrange: true,
           showgrid: true,
           gridcolor: borderColor,
           zeroline: true,
@@ -77,6 +78,7 @@ const Plot = ({
         },
         xaxis: {
           color: textColor,
+          fixedrange: true,
           showgrid: false,
           zeroline: false,
           tickvals: data.tickvals,

--- a/ui/src/pages/overview/entities/entities-columns.tsx
+++ b/ui/src/pages/overview/entities/entities-columns.tsx
@@ -19,7 +19,15 @@ export const columns: (
   {
     id: 'description',
     name: translate(STRING.FIELD_LABEL_DESCRIPTION),
-    renderCell: (item: Entity) => <BasicTableCell value={item.description} />,
+    renderCell: (item: Entity) => (
+      <BasicTableCell
+        style={{
+          width: '320px',
+          whiteSpace: 'normal',
+        }}
+        value={item.description}
+      />
+    ),
   },
   {
     id: 'created-at',

--- a/ui/src/pages/overview/entities/entities.tsx
+++ b/ui/src/pages/overview/entities/entities.tsx
@@ -52,7 +52,9 @@ export const Entities = ({
         isFetching={isFetching}
         tooltip={tooltip}
       >
-        {canCreate && <NewEntityDialog collection={collection} type={type} />}
+        {canCreate && (
+          <NewEntityDialog collection={collection} type={type} isCompact />
+        )}
       </PageHeader>
       <Table
         items={entities}

--- a/ui/src/pages/session-details/playback/playback.module.scss
+++ b/ui/src/pages/session-details/playback/playback.module.scss
@@ -49,6 +49,8 @@
 
 .licenseInfoWrapper {
   flex: 1;
+  text-align: right;
+
   p a {
     color: $color-generic-white;
   }
@@ -76,12 +78,17 @@
   .bottomBar {
     display: flex;
     flex-direction: column;
+    padding: 16px;
   }
 
   .captureNavigationWrapper {
     margin-bottom: 32px;
-    gap: 16px;
+    gap: 32px;
     flex-direction: column-reverse;
-    justify-content: center;
+    justify-content: flex-start;
+  }
+
+  .licenseInfoWrapper {
+    text-align: left;
   }
 }

--- a/ui/src/pages/session-details/playback/playback.tsx
+++ b/ui/src/pages/session-details/playback/playback.tsx
@@ -75,7 +75,7 @@ export const Playback = ({ session }: { session: SessionDetails }) => {
             setActiveCaptureId={setActiveCaptureId}
           />
           <div className={styles.licenseInfoWrapper}>
-            <LicenseInfo style={{ textAlign: 'right' }} />
+            <LicenseInfo />
           </div>
         </div>
         <div>


### PR DESCRIPTION
Some small tweaks to make small screen variant look a bit more polished. Before vs. after examples:

<img width="354" alt="Skärmavbild 2024-09-11 kl  23 05 55" src="https://github.com/user-attachments/assets/5c089276-24ad-4920-99fc-75129302f5ac">
<img width="361" alt="Skärmavbild 2024-09-11 kl  23 05 43" src="https://github.com/user-attachments/assets/b7a6c170-48d8-488a-a0e5-0091b8908dcc">

<img width="368" alt="Skärmavbild 2024-09-11 kl  23 10 21" src="https://github.com/user-attachments/assets/077f8bdf-486f-483d-b30b-0f6a4d931071">
<img width="364" alt="Skärmavbild 2024-09-11 kl  23 10 15" src="https://github.com/user-attachments/assets/b58107cf-3148-408d-ab91-db579d954046">

<img width="363" alt="Skärmavbild 2024-09-11 kl  23 07 20" src="https://github.com/user-attachments/assets/51267fb2-672c-4efe-bc39-29f9d55d919b">
<img width="368" alt="Skärmavbild 2024-09-11 kl  23 07 46" src="https://github.com/user-attachments/assets/e57c940d-7e5f-44ef-9c03-c651484632fb">