### PR TITLE
Restore search params after login

### DIFF
--- a/ui/src/components/header/header.tsx
+++ b/ui/src/components/header/header.tsx
@@ -67,7 +67,12 @@ export const Header = () => {
         ) : (
           <Link
             to={APP_ROUTES.LOGIN}
-            state={{ to: location.pathname }}
+            state={{
+              to: {
+                pathname: location.pathname,
+                search: location.search,
+              },
+            }}
             className={classNames(buttonStyles.button, buttonStyles.plain)}
           >
             <span className={buttonStyles.label}>

--- a/ui/src/pages/occurrence-details/occurrence-details.tsx
+++ b/ui/src/pages/occurrence-details/occurrence-details.tsx
@@ -184,7 +184,12 @@ export const OccurrenceDetails = ({
               label="Login to suggest ID"
               onClick={() =>
                 navigate(APP_ROUTES.LOGIN, {
-                  state: { to: location.pathname },
+                  state: {
+                    to: {
+                      pathname: location.pathname,
+                      search: location.search,
+                    },
+                  },
                 })
               }
             />


### PR DESCRIPTION
Fixes this comment from @mihow :
"if you log in while on session detail (to process or favorite a photo), it jumps to the beginning of the session afterwards"