### PR TITLE
Add taxon search to species table view

### DIFF
--- a/ami/main/api/views.py
+++ b/ami/main/api/views.py
@@ -667,18 +667,58 @@ class DetectionViewSet(DefaultViewSet):
     #             "detection_algorithm").all()
 
 
-class CustomDeterminationFilter(filters.BaseFilterBackend):
+class CustomTaxonFilter(filters.BaseFilterBackend):
+    """
+    Find a taxon and its children.
+    """
+
+    query_params = ["taxon"]
+
+    def get_filter_taxon(self, request: Request) -> Taxon | None:
+        taxon_id = None
+        for param in self.query_params:
+            taxon_id = request.query_params.get(param)
+            if taxon_id:
+                break
+        if not taxon_id:
+            return None
+
+        try:
+            # @TODO In the future filter by active taxa only, or any other required criteria (use the default queryset)
+            taxon = Taxon.objects.get(id=taxon_id)
+        except Taxon.DoesNotExist:
+            raise NotFound(f"No taxon found with id {taxon_id}")
+        else:
+            return taxon
+
     def filter_queryset(self, request, queryset, view):
-        determination_id = request.query_params.get("determination")
-        if determination_id:
-            try:
-                taxon = Taxon.objects.get(id=determination_id)
-                return queryset.filter(
-                    models.Q(determination=taxon) | models.Q(determination__parents_json__contains=[{"id": taxon.id}])
-                )
-            except Taxon.DoesNotExist:
-                return queryset.none()  # or just return queryset if you prefer
-        return queryset
+        taxon = self.get_filter_taxon(request)
+        if taxon:
+            # Here the queryset is the Taxon queryset
+            return queryset.filter(models.Q(id=taxon.pk) | models.Q(parents_json__contains=[{"id": taxon.pk}]))
+        else:
+            # No taxon id in the query params
+            return queryset
+
+
+class CustomOccurrenceDeterminationFilter(CustomTaxonFilter):
+    """
+    Find an occurrence that was determined to be a taxon or andy of the taxon's children.
+    """
+
+    # "determination" is what we are filtering by, but "taxon" is also a valid query param for convenience
+    # and consistency with the TaxonViewSet.
+    query_params = ["determination", "taxon"]
+
+    def filter_queryset(self, request, queryset, view):
+        taxon = self.get_filter_taxon(request)
+        if taxon:
+            # Here the queryset is the Occurrence queryset
+            return queryset.filter(
+                models.Q(determination=taxon) | models.Q(determination__parents_json__contains=[{"id": taxon.pk}])
+            )
+        else:
+            return queryset
 
 
 class OccurrenceViewSet(DefaultViewSet):
@@ -690,7 +730,7 @@ class OccurrenceViewSet(DefaultViewSet):
 
     serializer_class = OccurrenceSerializer
     # filter_backends = [CustomDeterminationFilter, DjangoFilterBackend, NullsLastOrderingFilter, SearchFilter]
-    filter_backends = DefaultViewSetMixin.filter_backends + [CustomDeterminationFilter]
+    filter_backends = DefaultViewSetMixin.filter_backends + [CustomOccurrenceDeterminationFilter]
     filterset_fields = ["event", "deployment", "project", "determination__rank"]
     ordering_fields = [
         "created_at",
@@ -756,6 +796,7 @@ class TaxonViewSet(DefaultViewSet):
 
     queryset = Taxon.objects.all()
     serializer_class = TaxonSerializer
+    filter_backends = DefaultViewSetMixin.filter_backends + [CustomTaxonFilter]
     filterset_fields = [
         "name",
         "rank",

--- a/ui/src/pages/occurrences/taxon-filter/taxon-filter.tsx
+++ b/ui/src/pages/occurrences/taxon-filter/taxon-filter.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef, useState } from 'react'
 import { useFilters } from 'utils/useFilters'
 import styles from './taxon-filter.module.scss'
 
-const FILTER_FIELD = 'determination'
+const FILTER_FIELD = 'taxon'
 
 export const TaxonFilter = () => {
   const containerRef = useRef<HTMLDivElement>(null)
@@ -13,7 +13,7 @@ export const TaxonFilter = () => {
   const { filters, addFilter, clearFilter } = useFilters()
 
   useEffect(() => {
-    // Clear taxon if determination filter is cleared
+    // Clear taxon if taxon filter is cleared
     const currentFilter = filters.find(
       (filter) => filter.field === FILTER_FIELD
     )

--- a/ui/src/pages/species-details/species-details.tsx
+++ b/ui/src/pages/species-details/species-details.tsx
@@ -45,7 +45,7 @@ export const SpeciesDetails = ({ species }: { species: Species }) => {
       value: species.numOccurrences || 'View all',
       to: getAppRoute({
         to: APP_ROUTES.OCCURRENCES({ projectId: projectId as string }),
-        filters: { determination: species.id },
+        filters: { taxon: species.id },
       }),
     },
     {

--- a/ui/src/pages/species/species-columns.tsx
+++ b/ui/src/pages/species/species-columns.tsx
@@ -77,7 +77,7 @@ export const columns: (projectId: string) => TableColumn<Species>[] = (
       <Link
         to={getAppRoute({
           to: APP_ROUTES.OCCURRENCES({ projectId }),
-          filters: { determination: item.id },
+          filters: { taxon: item.id },
         })}
       >
         <BasicTableCell value={item.numOccurrences} theme={CellTheme.Bubble} />

--- a/ui/src/pages/species/species.tsx
+++ b/ui/src/pages/species/species.tsx
@@ -8,6 +8,7 @@ import { PaginationBar } from 'design-system/components/pagination-bar/paginatio
 import { Table } from 'design-system/components/table/table/table'
 import { ToggleGroup } from 'design-system/components/toggle-group/toggle-group'
 import { Error } from 'pages/error/error'
+import { TaxonFilter } from 'pages/occurrences/taxon-filter/taxon-filter'
 import { SpeciesDetails } from 'pages/species-details/species-details'
 import { useContext, useEffect } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
@@ -51,6 +52,7 @@ export const Species = () => {
         isFetching={isFetching}
         showAppliedFilters
       >
+        <TaxonFilter />
         <ToggleGroup
           items={[
             {

--- a/ui/src/utils/getAppRoute.ts
+++ b/ui/src/utils/getAppRoute.ts
@@ -1,11 +1,11 @@
 type FilterType =
   | 'deployment'
   | 'event'
-  | 'determination'
   | 'occurrences__deployment'
   | 'occurrences__event'
   | 'occurrence'
   | 'capture'
+  | 'taxon'
   | 'timestamp'
 
 export const getAppRoute = ({

--- a/ui/src/utils/useFilters.ts
+++ b/ui/src/utils/useFilters.ts
@@ -19,7 +19,7 @@ const AVAILABLE_FILTERS = [
   },
   {
     label: 'Taxon',
-    field: 'determination',
+    field: 'taxon',
   },
 ]
 


### PR DESCRIPTION
Add the hierarchical taxa search to the Species tab. This uses the same component as the Occurrences tab. I updated the url param to be `taxon` for both placements. Even though they mean slightly different things in both contexts.

![image](https://github.com/user-attachments/assets/e616e125-3be8-43b4-9787-0442f42187b0)
