### PR TITLE
Filter processed images before each batch is sent

### DIFF
--- a/ami/ml/tasks.py
+++ b/ami/ml/tasks.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 def process_source_images_async(pipeline_choice: str, endpoint_url: str, image_ids: list[int], job_id: int | None):
     from ami.jobs.models import Job
     from ami.main.models import SourceImage
-    from ami.ml.models.pipeline import process_images, save_results
+    from ami.ml.models.pipeline import Pipeline, process_images, save_results
 
     job = None
     try:
@@ -22,8 +22,10 @@ def process_source_images_async(pipeline_choice: str, endpoint_url: str, image_i
         pass
 
     images = SourceImage.objects.filter(pk__in=image_ids)
+    pipeline = Pipeline.objects.get(slug=pipeline_choice)
+
     results = process_images(
-        pipeline_choice=pipeline_choice,
+        pipeline=pipeline,
         endpoint_url=endpoint_url,
         images=images,
         job_id=job_id,

--- a/ami/ml/tests.py
+++ b/ami/ml/tests.py
@@ -152,6 +152,12 @@ class TestPipeline(TestCase):
         remaining_images_to_process = len(images_again)
         self.assertEqual(remaining_images_to_process, total_images)
 
+    def _test_skip_existing_per_batch_during_processing(self):
+        # Send the same batch to two simultaneous processing pipelines
+        # @TODO this needs to test the `process_images()` function with a real pipeline
+        # @TODO enable test when a pipeline is added to the CI environment in PR #576
+        pass
+
     def test_unknown_algorithm_returned_by_backend(self):
         fake_results = self.fake_pipeline_results(self.test_images, self.pipeline)
 


### PR DESCRIPTION
This will allow multiple simultaneous jobs to run simultaneously without duplicating work. 

@TODO add test one #576 is ready