### PR TITLE
Use taxa list name as page title

### DIFF
--- a/ui/src/pages/species/species.tsx
+++ b/ui/src/pages/species/species.tsx
@@ -15,7 +15,7 @@ import { ColumnSettings } from 'design-system/components/table/column-settings/c
 import { Table } from 'design-system/components/table/table/table'
 import { ToggleGroup } from 'design-system/components/toggle-group/toggle-group'
 import { SpeciesDetails, TABS } from 'pages/species-details/species-details'
-import { useContext, useEffect } from 'react'
+import { useContext, useEffect, useMemo } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { BreadcrumbContext } from 'utils/breadcrumbContext'
 import { APP_ROUTES } from 'utils/constants'
@@ -54,6 +54,18 @@ export const Species = () => {
   const { selectedView, setSelectedView } = useSelectedView('table')
   const { taxaLists = [] } = useTaxaLists({ projectId: projectId as string })
   const { tags = [] } = useTags({ projectId: projectId as string })
+  const pageTitle = useMemo(() => {
+    const taxaListFilter = filters.find(
+      (filter) => filter.field === 'taxa_list_id'
+    )
+    const activeTaxaList = taxaListFilter
+      ? taxaLists.find((taxaList) => taxaList.id === taxaListFilter.value)
+      : undefined
+
+    return activeTaxaList
+      ? activeTaxaList.name
+      : translate(STRING.NAV_ITEM_TAXA)
+  }, [filters, taxaLists])
 
   return (
     <>
@@ -81,7 +93,7 @@ export const Species = () => {
             subTitle={translate(STRING.RESULTS, {
               total,
             })}
-            title={translate(STRING.NAV_ITEM_TAXA)}
+            title={pageTitle}
           >
             <ToggleGroup
               items={[


### PR DESCRIPTION
## Summary

When a taxa list is selected, @mihow suggested in https://github.com/RolnickLab/antenna/issues/796 we use the name as the page title.

## Screenshots

<img width="1728" height="1117" alt="Screenshot 2025-10-15 at 09 04 50" src="https://github.com/user-attachments/assets/dabd3dcb-3787-4c02-9cf2-399ce96bcab5" />