### PR TITLE
Chart tabs

### DIFF
--- a/ami/main/models.py
+++ b/ami/main/models.py
@@ -277,21 +277,32 @@ class Project(ProjectSettingsMixin, BaseModel):
         Data prepared for rendering charts with plotly.js on the overview page.
         """
 
-        plots = []
-
-        plots.append(charts.captures_per_hour(project_pk=self.pk))
-        if self.occurrences.exists():
-            plots.append(charts.detections_per_hour(project_pk=self.pk))
-            # plots.append(charts.occurrences_accumulated(project_pk=self.pk))
-        else:
-            plots.append(charts.events_per_month(project_pk=self.pk))
-            # plots.append(charts.captures_per_month(project_pk=self.pk))
-        plots.append(charts.project_top_taxa(project_pk=self.pk))
-        plots.append(charts.captures_per_month(project_pk=self.pk))
-        plots.append(charts.average_occurrences_per_month(project_pk=self.pk))
-        plots.append(charts.unique_species_per_month(project_pk=self.pk))
-
-        return plots
+        return [
+            {
+                "id": "captures",
+                "title": "Captures",
+                "plots": [
+                    charts.captures_per_hour(project_pk=self.pk),
+                    charts.captures_per_month(project_pk=self.pk),
+                ],
+            },
+            {
+                "id": "occurrences",
+                "title": "Occurrences",
+                "plots": [
+                    charts.detections_per_hour(project_pk=self.pk),
+                    charts.average_occurrences_per_month(project_pk=self.pk),
+                ],
+            },
+            {
+                "id": "taxa",
+                "title": "Taxa",
+                "plots": [
+                    charts.project_top_taxa(project_pk=self.pk),
+                    charts.unique_species_per_month(project_pk=self.pk),
+                ],
+            },
+        ]
 
     def update_related_calculated_fields(self):
         """

--- a/ui/src/data-services/models/project-details.ts
+++ b/ui/src/data-services/models/project-details.ts
@@ -4,15 +4,19 @@ import { Project } from './project'
 export type ServerProject = any // TODO: Update this type
 
 interface SummaryData {
+  id: string
   title: string
-  data: {
-    x: (string | number)[]
-    y: number[]
-    tickvals?: (string | number)[]
-    ticktext?: string[]
-  }
-  type: any
-  orientation: 'h' | 'v'
+  plots: {
+    title: string
+    data: {
+      x: (string | number)[]
+      y: number[]
+      tickvals?: (string | number)[]
+      ticktext?: string[]
+    }
+    type: any
+    orientation: 'h' | 'v'
+  }[]
 }
 
 interface Settings {

--- a/ui/src/pages/project/summary/summary.tsx
+++ b/ui/src/pages/project/summary/summary.tsx
@@ -3,6 +3,7 @@ import { ProjectDetails } from 'data-services/models/project-details'
 import { Box } from 'design-system/components/box/box'
 import { PlotGrid } from 'design-system/components/plot-grid/plot-grid'
 import { Plot } from 'design-system/components/plot/lazy-plot'
+import * as Tabs from 'design-system/components/tabs/tabs'
 import { UploadImagesDialog } from 'pages/captures/upload-images-dialog/upload-images-dialog'
 import { useState } from 'react'
 import { useOutletContext } from 'react-router-dom'
@@ -37,18 +38,33 @@ export const Summary = () => {
       ) : (
         <>
           <DeploymentsMap deployments={project.deployments} />
-          <PlotGrid>
-            {project.summaryData.map((summary, index) => (
-              <Box key={index}>
-                <Plot
-                  title={summary.title}
-                  data={summary.data}
-                  orientation={summary.orientation}
-                  type={summary.type}
+          <Tabs.Root defaultValue={project.summaryData[0]?.id}>
+            <Tabs.List>
+              {project.summaryData.map((section) => (
+                <Tabs.Trigger
+                  key={section.id}
+                  label={section.title}
+                  value={section.id}
                 />
-              </Box>
+              ))}
+            </Tabs.List>
+            {project.summaryData.map((section) => (
+              <Tabs.Content key={section.id} value={section.id}>
+                <PlotGrid>
+                  {section.plots.map((plot, index) => (
+                    <Box key={index}>
+                      <Plot
+                        data={plot.data}
+                        orientation={plot.orientation}
+                        title={plot.title}
+                        type={plot.type}
+                      />
+                    </Box>
+                  ))}
+                </PlotGrid>
+              </Tabs.Content>
             ))}
-          </PlotGrid>
+          </Tabs.Root>
         </>
       )}
     </div>


### PR DESCRIPTION
## Summary

The project overview has become a bit cluttered with charts and it's tricky to get an overview. In this PR we suggest splitting up the charts in sections and presenting them using a tab layout.

## Detailed Description

### How to Test the Changes

Changes must be tested locally since they include backend updates. 

### Screenshots
Before:
<img width="1728" height="1117" alt="Screenshot 2025-10-15 at 10 56 14" src="https://github.com/user-attachments/assets/0ed3b3d8-2057-42c0-a71e-17737cce09c3" />

After:
<img width="1728" height="1117" alt="Screenshot 2025-10-15 at 10 55 50" src="https://github.com/user-attachments/assets/1d49a0d9-eb83-4c88-8008-1127b0dee908" />

## Deployment Notes

Remember to deploy the backend after merge.