### PR TITLE
Bump occurrences page size

### DIFF
--- a/ui/src/pages/occurrences/occurrences.tsx
+++ b/ui/src/pages/occurrences/occurrences.tsx
@@ -59,7 +59,7 @@ export const Occurrences = () => {
     field: 'updated_at',
     order: 'desc',
   })
-  const { pagination, setPage } = usePagination()
+  const { pagination, setPage } = usePagination({ perPage: 50 })
   const { activeFilters, filters } = useFilters()
   const { occurrences, total, isLoading, isFetching, error } = useOccurrences({
     projectId,


### PR DESCRIPTION
### Summary
We have talked about bumping the occurrence page size (for example this was suggested by Maxim on a feedback session in Panama). The page size is currently set to 20, however larger pages will also take longer to load, so we need to find a balance.

Quick load time experiment:
- 20 items: 1.33 s
- 50 items: 2.22 s
- 100 items: 4.10 s

In the screenshots below, you can see what takes time is mostly waiting for the server, but also loading content.

I suggest we start updating to 50 and when we can improve the server response time in future, we could try 100?

### Screenshots from testing
<img width="1728" height="1117" alt="Screenshot 2025-10-22 at 13 04 50" src="https://github.com/user-attachments/assets/512e1676-653a-4dea-b0f3-2992fb2943e4" />

<img width="1728" height="1117" alt="Screenshot 2025-10-22 at 13 05 29" src="https://github.com/user-attachments/assets/180014cc-1933-4900-9da0-cf90879e8bbd" />

<img width="1728" height="1117" alt="Screenshot 2025-10-22 at 13 06 01" src="https://github.com/user-attachments/assets/2977996e-5c8f-4412-8794-735a26961d06" />