### PR TITLE
Add support for seasonal header

### DIFF
--- a/ui/src/components/header/antenna-halloween.svg
+++ b/ui/src/components/header/antenna-halloween.svg
@@ -1,0 +1,9 @@
+<svg width="160" height="160" viewBox="0 0 160 160" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M84.5 53.5338V69.5338H76.5V53.5338H84.5Z" fill="#00AE87"/>
+<path d="M56.5 73.7275C54.3478 58.414 43.9625 47.4954 28.8367 49.3401" stroke="#F2A31F" stroke-width="8" stroke-linecap="square"/>
+<path d="M104.5 73.7275C106.652 58.414 117.037 47.4954 132.163 49.3401" stroke="#F2A31F" stroke-width="8" stroke-linecap="square"/>
+<path d="M80.5 69.0676C56.1995 69.0676 36.5 88.7671 36.5 113.068H124.5C124.5 88.7671 104.801 69.0676 80.5 69.0676Z" fill="#F2A31F" stroke="#F2A31F" stroke-width="8" stroke-linecap="round"/>
+<path d="M64.5 76.5338L56.5 88.5338H72.5L64.5 76.5338Z" fill="black"/>
+<path d="M96.5 76.5338L88.5 88.5338H104.5L96.5 76.5338Z" fill="black"/>
+<path d="M62.5 100.534L68.5 106.534L74.5 100.534L80.5 106.534L86.5 100.534L92.5 106.534L98.5 100.534" stroke="black" stroke-width="4" stroke-linecap="square"/>
+</svg>

--- a/ui/src/components/header/header.tsx
+++ b/ui/src/components/header/header.tsx
@@ -3,16 +3,29 @@ import { useLogout } from 'data-services/hooks/auth/useLogout'
 import { Button, ButtonTheme } from 'design-system/components/button/button'
 import buttonStyles from 'design-system/components/button/button.module.scss'
 import { Icon, IconTheme, IconType } from 'design-system/components/icon/icon'
+import { BasicTooltip } from 'design-system/components/tooltip/basic-tooltip'
 import { Helmet } from 'react-helmet-async'
 import { Link, useLocation } from 'react-router-dom'
 import { APP_ROUTES, LANDING_PAGE_URL } from 'utils/constants'
 import { STRING, translate } from 'utils/language'
 import { usePageTitle } from 'utils/usePageTitle'
 import { useUser } from 'utils/user/userContext'
-import antenna from './antenna-primary.svg'
+import antennaHalloween from './antenna-halloween.svg'
+import antennaPrimary from './antenna-primary.svg'
 import styles from './header.module.scss'
 import { UserInfoDialog } from './user-info-dialog/user-info-dialog'
 import { VersionInfo } from './version-info/version-info'
+
+const LOGOS: { [key: string]: { image: string; tooltip?: string } } = {
+  default: {
+    image: antennaPrimary,
+  },
+  halloween: {
+    image: antennaHalloween,
+    tooltip: 'Happy Halloween!',
+  },
+}
+const LOGO = LOGOS[import.meta.env.VITE_ENV_LOGO] ?? LOGOS.default
 
 export const Header = () => {
   const location = useLocation()
@@ -25,15 +38,17 @@ export const Header = () => {
       <Helmet>
         <title>{pageTitle}</title>
       </Helmet>
-      <Link to="/" className={styles.logoContainer}>
-        <img
-          alt="Antenna"
-          src={antenna}
-          width={40}
-          height={40}
-          className={styles.logo}
-        />
-      </Link>
+      <BasicTooltip asChild content={LOGO.tooltip}>
+        <Link to="/" className={styles.logoContainer}>
+          <img
+            alt="Antenna"
+            src={LOGO.image}
+            width={40}
+            height={40}
+            className={styles.logo}
+          />
+        </Link>
+      </BasicTooltip>
       <VersionInfo />
       <div className={styles.rightContent}>
         <div className={styles.infoPages}>


### PR DESCRIPTION
Adding support for a seasonal logo that can be activated by setting `VITE_ENV_LOGO = 'halloween'` in `.env`. Just a small thing for fun :)

<img width="1728" height="1117" alt="Screenshot 2025-10-29 at 09 27 31" src="https://github.com/user-attachments/assets/5ac5d13d-f437-48f0-9101-84e692852396" />