### PR TITLE
chore(infra): add iam:PassRole for App Runner service-linked role

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,8 @@
+
+
+This folder adds one IAM statement needed by App Runner VPC Connector creation:
+- Grants iam:PassRole scoped by iam:AWSServiceName = apprunner.amazonaws.com
+- Uses Resource: "*" so AWS internals can pass the correct service linked role variant.
+
+File:
+- infra/iam_app_runner_policy_addition.json additive; merge this statement into the existing deploy policy. Nothing is replaced.

--- a/infra/iam_app_runner_policy.json
+++ b/infra/iam_app_runner_policy.json
@@ -1,0 +1,11 @@
+{
+  "Sid": "AllowPassRoleForAppRunnerServiceLinkedRole",
+  "Effect": "Allow",
+  "Action": "iam:PassRole",
+  "Resource": "*",
+  "Condition": {
+    "StringEquals": {
+      "iam:AWSServiceName": "apprunner.amazonaws.com"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Adds a single, additive IAM statement to allow `iam:PassRole` for the App Runner service-linked role.
This unblocks App Runner VPC connector creation (previously failing with AccessDenied).

### List of Changes
* Added `infra/iam_app_runner_policy_addition.json` (policy delta)
* Added `infra/README.md` 

### Related Issues
Internal deployment blocker: App Runner VPC connector creation failed due to missing PassRole.

## Detailed Description
App Runner needs permission for the deploy principal to `iam:PassRole` the App Runner service-linked role
during VPC connector creation/attachment. We scope this safely:
`Resource: "*"`, with `Condition`: `iam:AWSServiceName = apprunner.amazonaws.com`.

No existing statements are replaced.

### How to Test the Changes
1. Admin merges this statement into the deploy user/group/role policy in IAM.
2. Re-attempt creating the VPC connector in us-west-2
3. Expect success (no AccessDenied on service-linked role).

      ## Screenshots
      N/A (infra policy change)
      
      ## Deployment Notes
      No code changes. Admin only needs to merge this statement into the existing deploy policy.
