### PR TITLE
Include last day of the year in "Occurrences per day" chart

### DIFF
--- a/ami/main/charts.py
+++ b/ami/main/charts.py
@@ -437,7 +437,7 @@ def average_occurrences_per_day(project_pk: int, taxon_pk: int | None = None):
 
     if occurrences_per_day:
         occurrences_per_day_dict = {f"{d:%b %d}": count for d, count in occurrences_per_day if d is not None}
-        days = [(datetime.date(2000, 1, 1) + datetime.timedelta(days=i)) for i in range(365)]
+        days = [(datetime.date(2000, 1, 1) + datetime.timedelta(days=i)) for i in range(366)]
         counts = [occurrences_per_day_dict.get(f"{d:%b %d}", 0) for d in days]
 
         # Limit days and counts to show active period


### PR DESCRIPTION
## Summary

Occurrences last day of the year were not included in the "Occurrences per day" chart. This is because year 2000 (used as the reference) is a leap year (has 366 days).

## Detailed Description

### Screenshots

Before:
<img width="1728" height="1117" alt="Screenshot 2025-11-07 at 14 01 56" src="https://github.com/user-attachments/assets/77adfaba-a571-4d15-a9fb-76fc29c43c1e" />

After:
<img width="1728" height="1117" alt="Screenshot 2025-11-07 at 14 01 09" src="https://github.com/user-attachments/assets/8f2e4732-e6f1-4912-aecc-f9bc466268c5" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved leap year support in daily occurrence tracking to properly include February 29 on leap years, ensuring accurate day ranges and consistent display of daily statistics across all calendar years.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->