### PR TITLE
Apply Plotly code splitting

### DIFF
--- a/ui/src/pages/species-details/species-details.tsx
+++ b/ui/src/pages/species-details/species-details.tsx
@@ -9,7 +9,7 @@ import {
   InfoBlockField,
   InfoBlockFieldValue,
 } from 'design-system/components/info-block/info-block'
-import Plot from 'design-system/components/plot/plot'
+import { Plot } from 'design-system/components/plot/lazy-plot'
 import * as Tabs from 'design-system/components/tabs/tabs'
 import { ExternalLinkIcon } from 'lucide-react'
 import { buttonVariants, TaxonDetails } from 'nova-ui-kit'


### PR DESCRIPTION
The Plotly lib is very large, which means if we include it to our main JS bundle, it will affect our FCP metric (First Contentful Paint). By lazy loading this lib, we can present content to users sooner. Compared to other assets we load, a few MB might not seem like a big deal, but it's important to keep the main bundle as small as possible.

I had already prepared code for this, but forgot to apply it to the new species charts.

Before (Plotly part of main bundle):
<img width="636" height="25" alt="Screenshot 2025-11-10 at 12 16 23" src="https://github.com/user-attachments/assets/2fffd689-9969-4037-ae47-9a3d17a01d24" />

After (splitting Plotly code into a separate chunk):
<img width="634" height="49" alt="Screenshot 2025-11-10 at 12 13 35" src="https://github.com/user-attachments/assets/7f0ceade-cc07-496a-bb5a-c2e04e70eac1" />

You can see here the library itself actually way larger than the rest of the frontend app.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal component imports to utilize an optimized loading pattern for better efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->