### PR TITLE
Disable session auth to avoid cookie conflicts

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -369,7 +369,7 @@ CELERY_BROKER_CONNECTION_MAX_RETRIES = None  # Retry forever
 # django-rest-framework - https://www.django-rest-framework.org/api-guide/settings/
 REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": (
-        "rest_framework.authentication.SessionAuthentication",
+        # "rest_framework.authentication.SessionAuthentication",
         "rest_framework.authentication.TokenAuthentication",
     ),
     "DEFAULT_PERMISSION_CLASSES": ("ami.base.permissions.IsActiveStaffOrReadOnly",),


### PR DESCRIPTION
## Summary

Session auth is required to use the browsable API docs as an authenticated user, however we have a cooke conflict that causes API calls from the UI to get a CSRF token error. The browsable API docs are helpful for development but not required for production, so disabling session auth for the time being and leaving the API docs read-only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * API authentication updated. Token-based authentication is now the only supported authentication method; session-based authentication is no longer available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->