### PR TITLE
Fix map zoom

### DIFF
--- a/ui/src/design-system/map/multi-marker-map/multi-marker-map.tsx
+++ b/ui/src/design-system/map/multi-marker-map/multi-marker-map.tsx
@@ -4,7 +4,6 @@ import { useEffect, useMemo, useRef } from 'react'
 import { MapContainer, Marker, Popup, TileLayer } from 'react-leaflet'
 import {
   ATTRIBUTION,
-  DEFAULT_ZOOM,
   MAX_BOUNDS,
   MIN_ZOOM,
   TILE_LAYER_URL,
@@ -38,7 +37,7 @@ export const MultiMarkerMap = ({
 
   useEffect(() => {
     requestAnimationFrame(() => {
-      mapRef.current?.fitBounds(bounds, { maxZoom: DEFAULT_ZOOM })
+      mapRef.current?.fitBounds(bounds)
     })
   }, [mapRef, bounds])
 


### PR DESCRIPTION
Adjusting the initial zoom to make it possible to also see stations that are close. Now the zoom is only based on bounds, not a max value (I'm not sure why we had this restriction before?).

Before (this is 13 stations):
<img width="1728" height="1117" alt="Screenshot 2025-11-19 at 16 18 48" src="https://github.com/user-attachments/assets/467b0f94-4c26-40c1-9a6b-c392e41b82cb" />

After:
<img width="1728" height="1117" alt="Screenshot 2025-11-19 at 16 23 25" src="https://github.com/user-attachments/assets/fdd8b3f4-10d9-4d3c-9575-bf4eb73d6a68" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved map zoom behavior when displaying multiple markers by removing zoom constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->