### PR TITLE
Handle missing occurrence image

### DIFF
--- a/ui/src/pages/occurrences/occurrence-gallery.tsx
+++ b/ui/src/pages/occurrences/occurrence-gallery.tsx
@@ -5,6 +5,7 @@ import galleryStyles from 'components/gallery/gallery.module.scss'
 import { Occurrence } from 'data-services/models/occurrence'
 import { Taxon } from 'data-services/models/taxa'
 import cardStyles from 'design-system/components/card/card.module.scss'
+import { Icon, IconTheme, IconType } from 'design-system/components/icon/icon'
 import { LoadingSpinner } from 'design-system/components/loading-spinner/loading-spinner'
 import { BasicTooltip } from 'design-system/components/tooltip/basic-tooltip'
 import { CheckIcon } from 'lucide-react'
@@ -98,11 +99,31 @@ export const OccurrenceGallery = ({
                     className="w-full h-full relative cursor-pointer"
                     onClick={onCheckedToggle}
                   >
-                    <img src={image.src} className={cardStyles.image} />
+                    {image ? (
+                      <img src={image.src} className={cardStyles.image} />
+                    ) : (
+                      <div className={cardStyles.image}>
+                        <Icon
+                          type={IconType.Photograph}
+                          theme={IconTheme.Neutral}
+                          size={32}
+                        />
+                      </div>
+                    )}
                   </div>
                 ) : (
                   <Link className="w-full h-full relative" to={detailsRoute}>
-                    <img src={image.src} className={cardStyles.image} />
+                    {image ? (
+                      <img src={image.src} className={cardStyles.image} />
+                    ) : (
+                      <div className={cardStyles.image}>
+                        <Icon
+                          type={IconType.Photograph}
+                          theme={IconTheme.Neutral}
+                          size={32}
+                        />
+                      </div>
+                    )}
                   </Link>
                 )}
                 {selectable ? (


### PR DESCRIPTION
Sometimes, occurrences are missing images. In this case, it seems to be because of some issue during processing (see #1059), but it can also happen when processing is in progress (occurrence records are generated before crops are saved). We did not handle this in the new gallery view. In this PR, we fix this!

Before (gallery crashed):
<img width="1728" height="1117" alt="Screenshot 2025-11-19 at 16 25 13" src="https://github.com/user-attachments/assets/9ceac49b-61fc-4fae-a9e5-682438d90bb8" />

After:
<img width="1728" height="1117" alt="Screenshot 2025-11-19 at 16 28 27" src="https://github.com/user-attachments/assets/6c1a316b-ec4a-40a0-bcb2-7420dec014b7" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Occurrence gallery now displays placeholder icons for missing images instead of broken image references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->