### PR TITLE
Update README with build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,9 +144,13 @@ pip install -r requirements/local.txt
 
 #### Helpful Commands
 
-##### Run the docker compose stack in the background
+##### Run the Docker compose stack in the background
 
     docker compose up -d
+
+##### Rebuild Docker images
+
+    docker compose build
 
 ##### Watch the logs of Django & the backend workers
 
@@ -324,6 +328,7 @@ Antenna supports remote debugging with debugpy for both Django and Celery servic
 
 ### Troubleshooting
 
+- **Problems after pull**: If Dockerfiles or dependencies have been updated, make sure to rebuild the Docker images: `docker compose build`. For source code changes, this is not needed.
 - **Connection refused**: Make sure you copied `docker-compose.override-example.yml` to `docker-compose.override.yml`
 - **Debugger not stopping**: Verify breakpoints are set in code that actually executes
 - **Port conflicts**: Check that ports 5678 and 5679 aren't already in use on your host machine


### PR DESCRIPTION
Including the build command in the list of "Helpful Commands". Also adding a tip to the section "Troubleshooting".

@mihow do you think we should also add something about DB migrations? When it might be needed and what command to run? I'm thinking updates to DB table structure could be something else that might cause problems after pull.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated README with improved clarity on operational procedures
* Added troubleshooting guidance explaining when to rebuild Docker images after pulling changes (required for Dockerfile/dependency updates, not for source code changes)
* Enhanced documentation with commands for watching service logs and rebuilding images consistently across sections

<!-- end of auto-generated comment: release notes by coderabbit.ai -->