### PR TITLE
Fix: assign BasicMember role in members API so members can access draft project details

### DIFF
--- a/ami/users/api/views.py
+++ b/ami/users/api/views.py
@@ -63,7 +63,8 @@ class UserProjectMembershipViewSet(DefaultViewSet, ProjectMixin):
                 for r in Role.__subclasses__():
                     r.unassign_user(user, project)
                 role_cls.assign_user(user, project)
-                BasicMember.assign_user(user, project)
+                if role_cls is not BasicMember:
+                    BasicMember.assign_user(user, project)
             finally:
                 # Reconnect signal
                 m2m_changed.connect(manage_project_membership, sender=Group.user_set.through)
@@ -71,6 +72,7 @@ class UserProjectMembershipViewSet(DefaultViewSet, ProjectMixin):
     def perform_update(self, serializer):
         membership = self.get_object()
         project = membership.project
+        old_user = membership.user
         user = getattr(serializer, "_validated_user", None) or membership.user
         role_cls = getattr(serializer, "_validated_role_cls", None)
         if not role_cls:
@@ -84,11 +86,17 @@ class UserProjectMembershipViewSet(DefaultViewSet, ProjectMixin):
                 membership.user = user
                 membership.save()
 
+                # If user changed, revoke all roles from the old user
+                if old_user != user:
+                    for r in Role.__subclasses__():
+                        r.unassign_user(old_user, project)
+
                 # Unassign all roles, assign the chosen role, then BasicMember
                 for r in Role.__subclasses__():
                     r.unassign_user(user, project)
                 role_cls.assign_user(user, project)
-                BasicMember.assign_user(user, project)
+                if role_cls is not BasicMember:
+                    BasicMember.assign_user(user, project)
         finally:
             # Reconnect signal
             m2m_changed.connect(manage_project_membership, sender=Group.user_set.through)

--- a/ami/users/tests/test_membership_management_api.py
+++ b/ami/users/tests/test_membership_management_api.py
@@ -296,6 +296,37 @@ class TestMembersApiDraftProjectAccess(APITestCase):
     def test_member_added_via_api_can_access_draft_project_manager(self):
         self._add_member_and_assert_can_access_draft(self.user_project_manager, ProjectManager.__name__)
 
+    def test_member_role_update_retains_draft_access(self):
+        """After a role change via API, member should still access draft project."""
+        self._add_member_and_assert_can_access_draft(self.user_basic, BasicMember.__name__)
+
+        self.client.force_authenticate(self.superuser)
+        membership = UserProjectMembership.objects.get(project=self.project, user=self.user_basic)
+        update_url = f"{self.members_url}{membership.pk}/"
+        resp = self.client.patch(update_url, {"role_id": Researcher.__name__}, format="json")
+        self.assertEqual(resp.status_code, 200)
+
+        self.client.force_authenticate(self.user_basic)
+        detail_resp = self.client.get(self.detail_url)
+        self.assertEqual(detail_resp.status_code, 200, "Member should retain draft access after role update")
+
+    def test_deleted_member_cannot_access_draft_project(self):
+        """After membership deletion, former member should lose draft access."""
+        self._add_member_and_assert_can_access_draft(self.user_basic, BasicMember.__name__)
+
+        self.client.force_authenticate(self.superuser)
+        membership = UserProjectMembership.objects.get(project=self.project, user=self.user_basic)
+        delete_url = f"{self.members_url}{membership.pk}/"
+        self.client.delete(delete_url)
+
+        self.client.force_authenticate(self.user_basic)
+        detail_resp = self.client.get(self.detail_url)
+        self.assertIn(
+            detail_resp.status_code,
+            (403, 404),
+            "Removed member should not access draft project",
+        )
+
     def test_non_member_cannot_access_draft_project(self):
         self.client.force_authenticate(self.outsider)
         detail_resp = self.client.get(self.detail_url)


### PR DESCRIPTION
## Summary

Members added via the Members API received 403 errors when viewing draft project details. Draft permission checks use `BasicMember.has_role()`, but the API only assigned the requested role (Identifier, Researcher, etc.) without also assigning BasicMember.

### List of Changes

* `perform_create` and `perform_update` in `UserProjectMembershipViewSet` now assign BasicMember alongside the requested role (skipped when the requested role is already BasicMember)
* `perform_update` revokes roles from the old user when a membership's user is changed, preventing permission leaks
* `perform_destroy` revokes all roles (including BasicMember) before deleting the membership
* Added `TestMembersApiDraftProjectAccess` with 7 tests covering:
  - All 4 roles (BasicMember, Identifier, Researcher, ProjectManager) can access draft projects after creation
  - Role update retains draft access
  - Membership deletion revokes draft access
  - Non-members cannot access draft projects

## How to Test

```bash
docker compose -f docker-compose.ci.yml run --rm django python manage.py test ami.users.tests.test_membership_management_api.TestMembersApiDraftProjectAccess --keepdb
```

## Checklist

- [x] I have tested these changes appropriately.
- [x] I have added and/or modified relevant tests.
- [x] I updated relevant documentation or comments.
- [x] I have verified that this PR follows the project's coding standards.
- [ ] Any dependent changes have already been merged to main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two new user roles: Identifier and Researcher.
  * Members with assigned roles can access draft project details.

* **Bug Fixes**
  * Membership role changes and removals now correctly update a user’s access to draft projects.

* **Tests**
  * Added tests covering draft project access for role assignment, updates, and deletions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->