### PR TITLE
feat: configurable web worker count via WEB_WORKERS env var

### DIFF
--- a/compose/local/django/start
+++ b/compose/local/django/start
@@ -11,5 +11,11 @@ python manage.py migrate
 if [ "${DEBUGGER:-0}" = "1" ]; then
     exec python -Xfrozen_modules=off -m debugpy --listen 0.0.0.0:5678 -m uvicorn config.asgi:application --host 0.0.0.0
 else
-    exec uvicorn config.asgi:application --host 0.0.0.0 --reload --reload-include '*.html'
+    WORKERS="${WEB_WORKERS:-1}"
+    if [ "$WORKERS" -gt 1 ]; then
+        # --reload is incompatible with --workers, so skip it for multi-worker mode
+        exec uvicorn config.asgi:application --host 0.0.0.0 --workers "$WORKERS"
+    else
+        exec uvicorn config.asgi:application --host 0.0.0.0 --reload --reload-include '*.html'
+    fi
 fi

--- a/compose/production/django/start
+++ b/compose/production/django/start
@@ -6,4 +6,6 @@ set -o nounset
 
 python /app/manage.py collectstatic --noinput
 
-exec newrelic-admin run-program /usr/local/bin/gunicorn config.asgi --bind 0.0.0.0:5000 --chdir=/app -k uvicorn.workers.UvicornWorker
+exec newrelic-admin run-program /usr/local/bin/gunicorn config.asgi \
+    --workers "${WEB_WORKERS:-4}" \
+    --bind 0.0.0.0:5000 --chdir=/app -k uvicorn.workers.UvicornWorker


### PR DESCRIPTION
## Summary

- Local dev start script supports `WEB_WORKERS` env var; values > 1 run uvicorn with `--workers` (disables `--reload` since they're incompatible)
- Production start script passes explicit `--workers` to gunicorn (defaults to 4)

Single-worker mode (default) is unchanged — keeps `--reload` for hot reloading in dev.

## Context

During PSv2 integration testing, a single uvicorn worker couldn't handle concurrent requests from multiple DataLoader subprocesses. This makes it easy to run multiple workers locally with `WEB_WORKERS=2 docker compose up django`.

## Test plan

- [ ] `docker compose up django` — single worker with `--reload` (default, unchanged)
- [ ] `WEB_WORKERS=2 docker compose up django` — two workers, no `--reload`
- [ ] `DEBUGGER=1 docker compose up django` — debugpy mode unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Development and production servers now support configurable worker scaling via environment variable, enabling flexible performance tuning based on deployment needs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->