### PR TITLE
fix: include pipeline_slug in MinimalJobSerializer

### DIFF
--- a/ami/jobs/serializers.py
+++ b/ami/jobs/serializers.py
@@ -158,7 +158,7 @@ class JobSerializer(JobListSerializer):
 class MinimalJobSerializer(DefaultSerializer):
     """Minimal serializer returning only essential job fields."""
 
-    pipeline_slug = serializers.CharField(source="pipeline.slug", read_only=True)
+    pipeline_slug = serializers.CharField(source="pipeline.slug", read_only=True, allow_null=True)
 
     class Meta:
         model = Job


### PR DESCRIPTION
## Summary

- The `MinimalJobSerializer` (used for `ids_only=1` job list responses) was returning only `["id"]`
- ADC workers fetch jobs with `ids_only=1` and expect `pipeline_slug` in the response to know which pipeline to run
- Without it, Pydantic validation fails on the worker side and the job is skipped — images sit in NATS with no pickup

Adds `pipeline_slug` (sourced from `pipeline.slug`) to the minimal response.

## Test plan

- [ ] Verify `GET /api/v2/jobs/?ids_only=1&project_id=84` returns `pipeline_slug` for each job
- [ ] Confirm ADC worker successfully registers and pulls tasks after deploy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Job API responses now include pipeline slug information, allowing clients to directly identify and reference the associated pipeline. This improves data clarity and makes it easier to link jobs to their pipelines in UIs and integrations without changing existing identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->