### PR TITLE
fix: format taxa list files to pass Prettier check

### DIFF
--- a/ui/src/pages/taxa-list-details/add-taxa-list-taxon/add-taxa-list-taxon.tsx
+++ b/ui/src/pages/taxa-list-details/add-taxa-list-taxon/add-taxa-list-taxon.tsx
@@ -32,7 +32,9 @@ export const AddTaxaListTaxon = ({
       <div className="px-4 py-6">
         <div className="mb-4">
           <TaxonSelect
-            triggerLabel={taxon ? taxon.name : translate(STRING.SELECT_TAXON_PLACEHOLDER)}
+            triggerLabel={
+              taxon ? taxon.name : translate(STRING.SELECT_TAXON_PLACEHOLDER)
+            }
             taxon={taxon}
             onTaxonChange={setTaxon}
           />

--- a/ui/src/pages/taxa-list-details/taxa-list-details.tsx
+++ b/ui/src/pages/taxa-list-details/taxa-list-details.tsx
@@ -39,7 +39,9 @@ export const TaxaListDetails = () => {
 
   useEffect(() => {
     setDetailBreadcrumb(
-      taxaList ? { title: taxaList.name } : { title: `${translate(STRING.LOADING_DATA)}...` }
+      taxaList
+        ? { title: taxaList.name }
+        : { title: `${translate(STRING.LOADING_DATA)}...` }
     )
 
     return () => {


### PR DESCRIPTION
## Summary
- Fixes failing `lint` job on main (the `Check Format` step)
- Runs Prettier on two files introduced in #1094 that had long ternary expressions exceeding the print width

The formatting wasn't caught because the final commit in #1094 was merged before CI completed on that commit.