### PR TITLE
Skip sorting by filename

### DIFF
--- a/ui/src/pages/captures/capture-columns.tsx
+++ b/ui/src/pages/captures/capture-columns.tsx
@@ -137,7 +137,6 @@ export const columns: (projectId: string) => TableColumn<Capture>[] = (
   {
     id: 'filename',
     name: translate(STRING.FIELD_LABEL_FILENAME),
-    sortField: 'path',
     renderCell: (item: Capture) => <BasicTableCell value={item.filename} />,
   },
   {


### PR DESCRIPTION
## Summary

The sort key here was set to "path" which could be a bit confusing, since items will not actually be sorted by filename (see screenshot). Since backend sorting by filename is not supported, let's skip this for now. Probably not something users will use a lot anyways.

We will still allow users to sort by path (but then by applying sorting on this column directly).

<img width="471" height="574" alt="Screenshot 2026-03-03 at 11 05 30" src="https://github.com/user-attachments/assets/06fc6068-08e1-423d-b972-4195c3003861" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * The filename column in captures is no longer sortable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->