### PR TITLE
feat(roles): grant ML Data Manager collection and pipeline config perms

### DIFF
--- a/ami/users/roles.py
+++ b/ami/users/roles.py
@@ -141,6 +141,12 @@ class MLDataManager(Role):
         Project.Permissions.DELETE_JOB,
         Project.Permissions.DELETE_OCCURRENCES,
         Project.Permissions.CREATE_PROJECT_PIPELINE_CONFIG,
+        Project.Permissions.UPDATE_PROJECT_PIPELINE_CONFIG,
+        Project.Permissions.DELETE_PROJECT_PIPELINE_CONFIG,
+        Project.Permissions.CREATE_COLLECTION,
+        Project.Permissions.UPDATE_COLLECTION,
+        Project.Permissions.DELETE_COLLECTION,
+        Project.Permissions.POPULATE_COLLECTION,
     }
 
 


### PR DESCRIPTION
## Summary

Follows up on #1212. Adds more permissions to the **ML Data Manager** role so they can fully manage the resources needed to run batch ML jobs:

- **Capture sets (collections):** `CREATE_COLLECTION`, `UPDATE_COLLECTION`, `DELETE_COLLECTION`, `POPULATE_COLLECTION`
- **Pipeline configs:** `UPDATE_PROJECT_PIPELINE_CONFIG`, `DELETE_PROJECT_PIPELINE_CONFIG` (already had `CREATE`)

These also flow to **Project Manager** via role inheritance.

## Test plan

- [x] `TestRolePermissions` — all 4 role tests pass (ProjectManager already expected these as True)
- [x] `TestMLDataManagerCanRunBatchMLJob` — still passes
- [x] `ami.users.tests` — all 30 role/membership tests pass
- [x] Pre-commit hooks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded MLDataManager role permissions to include collection management (create, update, delete, populate) and additional pipeline configuration operations (update, delete).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->