### PR TITLE
UI cleanup (part 4)

### DIFF
--- a/ui/src/components/form/layout/layout.module.scss
+++ b/ui/src/components/form/layout/layout.module.scss
@@ -57,23 +57,8 @@
   gap: 16px;
 }
 
-.formMessage {
-  width: 100%;
-  @include paragraph-small();
-  padding: 8px 16px;
-  background-color: $color-success-100;
-  color: $color-success-700;
-  box-sizing: border-box;
-  border-radius: 6px;
-}
-
 .formError {
-  width: 100%;
-  @include paragraph-small();
   padding: 8px 32px;
-  background-color: $color-destructive-100;
-  color: $color-destructive-600;
-  box-sizing: border-box;
 
   &.inDialog {
     position: sticky;

--- a/ui/src/components/form/layout/layout.tsx
+++ b/ui/src/components/form/layout/layout.tsx
@@ -34,8 +34,10 @@ export const FormMessage = ({
         className
       )}
     >
-      {withIcon ? <Icon className="inline w-4 h-4 mr-2" /> : null}
-      <span>{message}</span>
+      <span>
+        {withIcon ? <Icon className="inline w-4 h-4 mr-2" /> : null}
+        {message}
+      </span>
       {children}
     </div>
   )

--- a/ui/src/components/form/layout/layout.tsx
+++ b/ui/src/components/form/layout/layout.tsx
@@ -4,6 +4,7 @@ import { CSSProperties, ReactNode } from 'react'
 import styles from './layout.module.scss'
 
 export const FormMessage = ({
+  children,
   className,
   message,
   theme = 'success',
@@ -13,6 +14,7 @@ export const FormMessage = ({
   message: string
   theme?: 'success' | 'warning' | 'destructive'
   withIcon?: boolean
+  children?: ReactNode
 }) => {
   const Icon = {
     success: LightbulbIcon,
@@ -34,6 +36,7 @@ export const FormMessage = ({
     >
       {withIcon ? <Icon className="inline w-4 h-4 mr-2" /> : null}
       <span>{message}</span>
+      {children}
     </div>
   )
 }

--- a/ui/src/components/form/layout/layout.tsx
+++ b/ui/src/components/form/layout/layout.tsx
@@ -1,21 +1,42 @@
 import classNames from 'classnames'
+import { CircleAlert, InfoIcon, LightbulbIcon } from 'lucide-react'
 import { CSSProperties, ReactNode } from 'react'
 import styles from './layout.module.scss'
 
 export const FormMessage = ({
-  intro,
+  className,
   message,
-  style,
+  theme = 'success',
+  withIcon,
 }: {
-  intro?: string
+  className?: string
   message: string
-  style?: CSSProperties
-}) => (
-  <div className={styles.formMessage} style={style}>
-    {intro ? <span className={styles.intro}>{intro}: </span> : null}
-    <span>{message}</span>
-  </div>
-)
+  theme?: 'success' | 'warning' | 'destructive'
+  withIcon?: boolean
+}) => {
+  const Icon = {
+    success: LightbulbIcon,
+    warning: InfoIcon,
+    destructive: CircleAlert,
+  }[theme]
+
+  return (
+    <div
+      className={classNames(
+        'px-4 py-2 rounded-md body-small',
+        {
+          'bg-[#d8f2ec] text-[#078c6e]': theme === 'success',
+          'bg-warning-50 text-warning-700': theme === 'warning',
+          'bg-destructive-50 text-destructive-700': theme === 'destructive',
+        },
+        className
+      )}
+    >
+      {withIcon ? <Icon className="inline w-4 h-4 mr-2" /> : null}
+      <span>{message}</span>
+    </div>
+  )
+}
 
 export const FormError = ({
   inDialog,
@@ -29,7 +50,11 @@ export const FormError = ({
   style?: CSSProperties
 }) => (
   <div
-    className={classNames(styles.formError, { [styles.inDialog]: inDialog })}
+    className={classNames(
+      styles.formError,
+      'w-full bg-destructive-50 text-destructive-700 body-small',
+      { [styles.inDialog]: inDialog }
+    )}
     style={style}
   >
     {intro ? <span className={styles.intro}>{intro}: </span> : null}

--- a/ui/src/design-system/components/button/docs-link.tsx
+++ b/ui/src/design-system/components/button/docs-link.tsx
@@ -1,4 +1,4 @@
-import { BookOpenIcon } from 'lucide-react'
+import { BookOpenIcon, ChevronRight } from 'lucide-react'
 import { buttonVariants } from 'nova-ui-kit'
 import { STRING, translate } from 'utils/language'
 import { BasicTooltip } from '../tooltip/basic-tooltip'
@@ -24,8 +24,14 @@ export const DocsLink = ({
       rel="noreferrer"
       target="_blank"
     >
-      <BookOpenIcon className="w-4 h-4" />
-      {isCompact ? null : <span>{translate(STRING.VIEW_DOCS)}</span>}
+      {isCompact ? (
+        <BookOpenIcon className="w-4 h-4" />
+      ) : (
+        <>
+          <span>{translate(STRING.VIEW_DOCS)}</span>
+          <ChevronRight className="w-4 h-4" />
+        </>
+      )}
     </a>
   </BasicTooltip>
 )

--- a/ui/src/design-system/components/info-tooltip.tsx
+++ b/ui/src/design-system/components/info-tooltip.tsx
@@ -18,9 +18,11 @@ export const InfoTooltip = (props: {
           <InfoIcon className="w-4 h-4" />
         </Button>
       </Tooltip.Trigger>
-      <Tooltip.Content side="bottom" className="p-4 max-w-xs">
-        <Info {...props} />
-      </Tooltip.Content>
+      <Tooltip.Portal>
+        <Tooltip.Content side="bottom" className="p-4 max-w-xs">
+          <Info {...props} />
+        </Tooltip.Content>
+      </Tooltip.Portal>
     </Tooltip.Root>
   </Tooltip.Provider>
 )

--- a/ui/src/design-system/components/select/capture-set-picker.tsx
+++ b/ui/src/design-system/components/select/capture-set-picker.tsx
@@ -1,7 +1,9 @@
 import { FormMessage } from 'components/form/layout/layout'
 import { useCaptureSets } from 'data-services/hooks/capture-sets/useCaptureSets'
+import { ChevronRight } from 'lucide-react'
 import { Select } from 'nova-ui-kit'
-import { useParams } from 'react-router-dom'
+import { Link, useParams } from 'react-router-dom'
+import { APP_ROUTES } from 'utils/constants'
 import { STRING, translate } from 'utils/language'
 
 export const CaptureSetPicker = ({
@@ -39,11 +41,26 @@ export const CaptureSetPicker = ({
       </Select.Root>
       {captureSet?.numImages !== undefined ? (
         captureSet.numImages === 0 ? (
-          <FormMessage
-            message={translate(STRING.MESSAGE_CAPTURE_SET_EMPTY)}
-            theme="warning"
-            withIcon
-          />
+          <div className="flex flex-col gap-4">
+            <FormMessage
+              className="flex justify-between gap-4"
+              message={translate(STRING.MESSAGE_CAPTURE_SET_EMPTY)}
+              theme="warning"
+              withIcon
+            >
+              {captureSet.canPopulate ? (
+                <Link
+                  className="font-bold"
+                  to={APP_ROUTES.CAPTURE_SETS({
+                    projectId: projectId as string,
+                  })}
+                >
+                  <span>{translate(STRING.POPULATE)}</span>
+                  <ChevronRight className="inline w-4 h-4 ml-2" />
+                </Link>
+              ) : null}
+            </FormMessage>
+          </div>
         ) : (
           <FormMessage
             message={translate(STRING.MESSAGE_CAPTURE_SET_COUNT, {

--- a/ui/src/design-system/components/select/capture-set-picker.tsx
+++ b/ui/src/design-system/components/select/capture-set-picker.tsx
@@ -1,15 +1,17 @@
 import { FormMessage } from 'components/form/layout/layout'
 import { useCaptureSets } from 'data-services/hooks/capture-sets/useCaptureSets'
-import { ChevronRight } from 'lucide-react'
-import { Select } from 'nova-ui-kit'
+import { ChevronRight, XIcon } from 'lucide-react'
+import { Button, Select } from 'nova-ui-kit'
 import { Link, useParams } from 'react-router-dom'
 import { APP_ROUTES } from 'utils/constants'
 import { STRING, translate } from 'utils/language'
 
 export const CaptureSetPicker = ({
+  clearable,
   value: _value,
   onValueChange,
 }: {
+  clearable?: boolean
   value?: string
   onValueChange: (value?: string) => void
 }) => {
@@ -22,23 +24,36 @@ export const CaptureSetPicker = ({
 
   return (
     <div className="flex flex-col gap-4">
-      <Select.Root
-        key={value}
-        disabled={isLoading || captureSets.length === 0}
-        onValueChange={onValueChange}
-        value={value}
-      >
-        <Select.Trigger loading={isLoading}>
-          <Select.Value placeholder={translate(STRING.SELECT_PLACEHOLDER)} />
-        </Select.Trigger>
-        <Select.Content className="max-h-72">
-          {captureSets.map((c) => (
-            <Select.Item key={c.id} value={c.id}>
-              {c.name}
-            </Select.Item>
-          ))}
-        </Select.Content>
-      </Select.Root>
+      <div className="flex items-center justify-between gap-2">
+        <Select.Root
+          key={value}
+          disabled={isLoading || captureSets.length === 0}
+          onValueChange={onValueChange}
+          value={value}
+        >
+          <Select.Trigger loading={isLoading}>
+            <Select.Value placeholder={translate(STRING.SELECT_PLACEHOLDER)} />
+          </Select.Trigger>
+          <Select.Content className="max-h-72">
+            {captureSets.map((c) => (
+              <Select.Item key={c.id} value={c.id}>
+                {c.name}
+              </Select.Item>
+            ))}
+          </Select.Content>
+        </Select.Root>
+        {clearable && _value && (
+          <Button
+            aria-label={translate(STRING.CLEAR)}
+            className="shrink-0 text-muted-foreground"
+            onClick={() => onValueChange()}
+            size="icon"
+            variant="ghost"
+          >
+            <XIcon className="w-4 h-4" />
+          </Button>
+        )}
+      </div>
       {captureSet?.numImages !== undefined ? (
         captureSet.numImages === 0 ? (
           <div className="flex flex-col gap-4">

--- a/ui/src/design-system/components/select/capture-set-picker.tsx
+++ b/ui/src/design-system/components/select/capture-set-picker.tsx
@@ -1,0 +1,58 @@
+import { FormMessage } from 'components/form/layout/layout'
+import { useCaptureSets } from 'data-services/hooks/capture-sets/useCaptureSets'
+import { Select } from 'nova-ui-kit'
+import { useParams } from 'react-router-dom'
+import { STRING, translate } from 'utils/language'
+
+export const CaptureSetPicker = ({
+  value: _value,
+  onValueChange,
+}: {
+  value?: string
+  onValueChange: (value?: string) => void
+}) => {
+  const { projectId } = useParams()
+  const { captureSets = [], isLoading } = useCaptureSets({
+    projectId: projectId as string,
+  })
+  const captureSet = captureSets.find((c) => c.id === _value)
+  const value = captureSet ? _value : ''
+
+  return (
+    <div className="flex flex-col gap-4">
+      <Select.Root
+        key={value}
+        disabled={isLoading || captureSets.length === 0}
+        onValueChange={onValueChange}
+        value={value}
+      >
+        <Select.Trigger loading={isLoading}>
+          <Select.Value placeholder={translate(STRING.SELECT_PLACEHOLDER)} />
+        </Select.Trigger>
+        <Select.Content className="max-h-72">
+          {captureSets.map((c) => (
+            <Select.Item key={c.id} value={c.id}>
+              {c.name}
+            </Select.Item>
+          ))}
+        </Select.Content>
+      </Select.Root>
+      {captureSet?.numImages !== undefined ? (
+        captureSet.numImages === 0 ? (
+          <FormMessage
+            message={translate(STRING.MESSAGE_CAPTURE_SET_EMPTY)}
+            theme="warning"
+            withIcon
+          />
+        ) : (
+          <FormMessage
+            message={translate(STRING.MESSAGE_CAPTURE_SET_COUNT, {
+              total: captureSet.numImages.toLocaleString(),
+            })}
+            withIcon
+          />
+        )
+      ) : null}
+    </div>
+  )
+}

--- a/ui/src/pages/captures/capture-columns.tsx
+++ b/ui/src/pages/captures/capture-columns.tsx
@@ -47,7 +47,7 @@ export const columns = ({
   },
   {
     id: 'timestamp',
-    name: translate(STRING.FIELD_LABEL_TIMESTAMP),
+    name: translate(STRING.FIELD_LABEL_CAPTURE),
     sortField: 'timestamp',
     renderCell: (item: Capture) => {
       const detailsRoute = item.sessionId
@@ -67,6 +67,7 @@ export const columns = ({
           <Link to={detailsRoute}>
             <BasicTableCell
               value={item.dateTimeLabel}
+              details={[`${translate(STRING.FIELD_LABEL_ID)}: ${item.id}`]}
               theme={CellTheme.Primary}
             />
           </Link>

--- a/ui/src/pages/deployment-details/deployment-details-form/deployment-details-form.tsx
+++ b/ui/src/pages/deployment-details/deployment-details-form/deployment-details-form.tsx
@@ -51,7 +51,7 @@ export const DeploymentDetailsForm = ({
           latitude: deployment.latitude,
           longitude: deployment.longitude,
         },
-        isValid: startValid,
+        isValid: true,
       },
       [Section.SourceImages]: {
         values: {
@@ -59,7 +59,7 @@ export const DeploymentDetailsForm = ({
           dataSourceSubdir: deployment.dataSourceSubdir,
           dataSourceRegex: deployment.dataSourceRegex,
         },
-        isValid: startValid,
+        isValid: true,
       },
     }}
   >

--- a/ui/src/pages/deployment-details/deployment-details-info.tsx
+++ b/ui/src/pages/deployment-details/deployment-details-info.tsx
@@ -46,6 +46,12 @@ export const DeploymentDetailsInfo = ({
         <FormSection title={translate(STRING.FIELD_LABEL_GENERAL)}>
           <FormRow>
             <InputValue
+              label={translate(STRING.FIELD_LABEL_ID)}
+              value={deployment.id}
+            />
+          </FormRow>
+          <FormRow>
+            <InputValue
               label={translate(STRING.FIELD_LABEL_NAME)}
               value={deployment.name}
             />

--- a/ui/src/pages/deployments/deployment-columns.tsx
+++ b/ui/src/pages/deployments/deployment-columns.tsx
@@ -54,7 +54,11 @@ export const columns = ({
           keepSearchParams: true,
         })}
       >
-        <BasicTableCell value={item.name} theme={CellTheme.Primary} />
+        <BasicTableCell
+          value={item.name}
+          details={[`${translate(STRING.FIELD_LABEL_ID)}: ${item.id}`]}
+          theme={CellTheme.Primary}
+        />
       </Link>
     ),
   },

--- a/ui/src/pages/job-details/job-details-form/job-details-form.tsx
+++ b/ui/src/pages/job-details/job-details-form/job-details-form.tsx
@@ -10,6 +10,7 @@ import {
 import { FormConfig } from 'components/form/types'
 import { API_ROUTES } from 'data-services/constants'
 import { useProjectDetails } from 'data-services/hooks/projects/useProjectDetails'
+import { DocsLink } from 'design-system/components/button/docs-link'
 import { SaveButton } from 'design-system/components/button/save-button'
 import { Checkbox } from 'design-system/components/checkbox/checkbox'
 import { InputContent } from 'design-system/components/input/input'
@@ -17,7 +18,7 @@ import { CaptureSetPicker } from 'design-system/components/select/capture-set-pi
 import { EntityPicker } from 'design-system/components/select/entity-picker'
 import { useForm } from 'react-hook-form'
 import { useParams } from 'react-router-dom'
-import { APP_ROUTES } from 'utils/constants'
+import { APP_ROUTES, DOCS_LINKS } from 'utils/constants'
 import { STRING, translate } from 'utils/language'
 import { useFormError } from 'utils/useFormError'
 
@@ -100,11 +101,14 @@ export const JobDetailsForm = ({
         />
       ) : null}
       <FormSection>
-        <FormMessage
-          message="Batch processing is currently in development and problems are likely to occur. If you need data processed, we recommend to reach out to the team for support. Thank you for your patience!"
-          theme="destructive"
-          withIcon
-        />
+        <div className="flex flex-col items-end gap-4">
+          <FormMessage
+            message="Batch processing is currently in development and problems are likely to occur. If you need data processed, we recommend to reach out to the team for support. Thank you for your patience!"
+            theme="warning"
+            withIcon
+          />
+          <DocsLink href={DOCS_LINKS.PROCESSING_DATA} />
+        </div>
         <FormRow>
           <FormField
             name="name"

--- a/ui/src/pages/job-details/job-details-form/job-details-form.tsx
+++ b/ui/src/pages/job-details/job-details-form/job-details-form.tsx
@@ -3,6 +3,7 @@ import { FormField } from 'components/form/form-field'
 import {
   FormActions,
   FormError,
+  FormMessage,
   FormRow,
   FormSection,
 } from 'components/form/layout/layout'
@@ -12,6 +13,7 @@ import { useProjectDetails } from 'data-services/hooks/projects/useProjectDetail
 import { SaveButton } from 'design-system/components/button/save-button'
 import { Checkbox } from 'design-system/components/checkbox/checkbox'
 import { InputContent } from 'design-system/components/input/input'
+import { CaptureSetPicker } from 'design-system/components/select/capture-set-picker'
 import { EntityPicker } from 'design-system/components/select/entity-picker'
 import { useForm } from 'react-hook-form'
 import { useParams } from 'react-router-dom'
@@ -96,14 +98,13 @@ export const JobDetailsForm = ({
           intro={translate(STRING.MESSAGE_COULD_NOT_SAVE)}
           message={errorMessage}
         />
-      ) : (
-        <FormError
-          inDialog
-          intro="Warning"
-          message="Batch processing is currently in development and problems are likely to occur. If you need data processed, we recommend to reach out to the team for support. Thank you for your patience!"
-        />
-      )}
+      ) : null}
       <FormSection>
+        <FormMessage
+          message="Batch processing is currently in development and problems are likely to occur. If you need data processed, we recommend to reach out to the team for support. Thank you for your patience!"
+          theme="destructive"
+          withIcon
+        />
         <FormRow>
           <FormField
             name="name"
@@ -142,8 +143,7 @@ export const JobDetailsForm = ({
                   },
                 }}
               >
-                <EntityPicker
-                  collection={API_ROUTES.CAPTURE_SETS}
+                <CaptureSetPicker
                   onValueChange={field.onChange}
                   value={field.value}
                 />

--- a/ui/src/pages/project-details/delete-project-dialog.tsx
+++ b/ui/src/pages/project-details/delete-project-dialog.tsx
@@ -1,4 +1,3 @@
-import classNames from 'classnames'
 import { DeleteForm } from 'components/form/delete-form/delete-form'
 import { useDeleteProject } from 'data-services/hooks/projects/useDeleteProject'
 import * as Dialog from 'design-system/components/dialog/dialog'
@@ -8,7 +7,6 @@ import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { APP_ROUTES } from 'utils/constants'
 import { STRING, translate } from 'utils/language'
-import styles from './styles.module.scss'
 
 export const DeleteProjectDialog = ({ id }: { id: string }) => {
   const navigate = useNavigate()
@@ -29,16 +27,14 @@ export const DeleteProjectDialog = ({ id }: { id: string }) => {
         </Button>
       </Dialog.Trigger>
       <Dialog.Content ariaCloselabel={translate(STRING.CLOSE)} isCompact>
-        <div className={classNames(styles.content, styles.compact)}>
-          <DeleteForm
-            error={error}
-            type={translate(STRING.ENTITY_TYPE_PROJECT)}
-            isLoading={isLoading}
-            isSuccess={isSuccess}
-            onCancel={() => setIsOpen(false)}
-            onSubmit={() => deleteProject(id)}
-          />
-        </div>
+        <DeleteForm
+          error={error}
+          type={translate(STRING.ENTITY_TYPE_PROJECT)}
+          isLoading={isLoading}
+          isSuccess={isSuccess}
+          onCancel={() => setIsOpen(false)}
+          onSubmit={() => deleteProject(id)}
+        />
       </Dialog.Content>
     </Dialog.Root>
   )

--- a/ui/src/pages/project-details/new-project-dialog.tsx
+++ b/ui/src/pages/project-details/new-project-dialog.tsx
@@ -8,7 +8,6 @@ import { APP_ROUTES } from 'utils/constants'
 import { getAppRoute } from 'utils/getAppRoute'
 import { STRING, translate } from 'utils/language'
 import { NewProjectForm } from './new-project-form'
-import styles from './styles.module.scss'
 
 const CLOSE_TIMEOUT = 1000
 
@@ -37,30 +36,28 @@ export const NewProjectDialog = ({
       </Dialog.Trigger>
       <Dialog.Content ariaCloselabel={translate(STRING.CLOSE)} isCompact>
         <Dialog.Header title={label} />
-        <div className={styles.content}>
-          <NewProjectForm
-            error={error}
-            isLoading={isLoading}
-            isSuccess={isSuccess}
-            onSubmit={async (data) => {
-              const response = await createProject(data)
+        <NewProjectForm
+          error={error}
+          isLoading={isLoading}
+          isSuccess={isSuccess}
+          onSubmit={async (data) => {
+            const response = await createProject(data)
 
-              setTimeout(() => {
-                setIsOpen(false)
-              }, CLOSE_TIMEOUT)
+            setTimeout(() => {
+              setIsOpen(false)
+            }, CLOSE_TIMEOUT)
 
-              if (response.data.id) {
-                navigate(
-                  getAppRoute({
-                    to: APP_ROUTES.PROJECT_DETAILS({
-                      projectId: `${response.data.id}`,
-                    }),
-                  })
-                )
-              }
-            }}
-          />
-        </div>
+            if (response.data.id) {
+              navigate(
+                getAppRoute({
+                  to: APP_ROUTES.PROJECT_DETAILS({
+                    projectId: `${response.data.id}`,
+                  }),
+                })
+              )
+            }
+          }}
+        />
       </Dialog.Content>
     </Dialog.Root>
   )

--- a/ui/src/pages/project-details/styles.module.scss
+++ b/ui/src/pages/project-details/styles.module.scss
@@ -1,9 +1,0 @@
-.content {
-  width: 720px;
-  max-width: 100%;
-  box-sizing: border-box;
-
-  &.compact {
-    width: 320px;
-  }
-}

--- a/ui/src/pages/project/capture-sets/capture-set-columns.tsx
+++ b/ui/src/pages/project/capture-sets/capture-set-columns.tsx
@@ -1,3 +1,4 @@
+import { FormMessage } from 'components/form/layout/layout'
 import { API_ROUTES } from 'data-services/constants'
 import { CaptureSet } from 'data-services/models/capture-set'
 import { BasicTableCell } from 'design-system/components/table/basic-table-cell/basic-table-cell'
@@ -52,16 +53,22 @@ export const columns = ({
       type: translate(STRING.ENTITY_TYPE_CAPTURE_SET),
     }),
     renderCell: (item: CaptureSet) => {
-      if (!item.currentJob) {
-        return <></>
+      if (item.canPopulate && item.numImages === 0) {
+        return (
+          <BasicTableCell>
+            <PopulateCaptureSet captureSet={item} />
+          </BasicTableCell>
+        )
       }
 
-      return (
+      return item.currentJob ? (
         <StatusTableCell
           color={item.currentJob.status.color}
           details={item.currentJob.type.label}
           label={item.currentJob.status.label}
         />
+      ) : (
+        <></>
       )
     },
   },
@@ -72,16 +79,18 @@ export const columns = ({
     styles: {
       textAlign: TextAlign.Right,
     },
-    renderCell: (item: CaptureSet) => (
-      <Link
-        to={getAppRoute({
-          to: APP_ROUTES.JOBS({ projectId }),
-          filters: { source_image_collection: item.id },
-        })}
-      >
-        <BasicTableCell value={item.numJobs} theme={CellTheme.Bubble} />
-      </Link>
-    ),
+    renderCell: (item: CaptureSet) => {
+      return (
+        <Link
+          to={getAppRoute({
+            to: APP_ROUTES.JOBS({ projectId }),
+            filters: { source_image_collection: item.id },
+          })}
+        >
+          <BasicTableCell value={item.numJobs} theme={CellTheme.Bubble} />
+        </Link>
+      )
+    },
   },
   {
     id: 'captures',
@@ -91,16 +100,30 @@ export const columns = ({
     styles: {
       textAlign: TextAlign.Right,
     },
-    renderCell: (item: CaptureSet) => (
-      <Link
-        to={getAppRoute({
-          to: APP_ROUTES.CAPTURES({ projectId }),
-          filters: { collections: item.id },
-        })}
-      >
-        <BasicTableCell value={item.numImages} theme={CellTheme.Bubble} />
-      </Link>
-    ),
+    renderCell: (item: CaptureSet) => {
+      if (item.canPopulate && item.numImages === 0) {
+        return (
+          <BasicTableCell>
+            <FormMessage
+              message={translate(STRING.MESSAGE_CAPTURE_SET_EMPTY)}
+              theme="warning"
+              withIcon
+            />
+          </BasicTableCell>
+        )
+      }
+
+      return (
+        <Link
+          to={getAppRoute({
+            to: APP_ROUTES.CAPTURES({ projectId }),
+            filters: { collections: item.id },
+          })}
+        >
+          <BasicTableCell value={item.numImages} theme={CellTheme.Bubble} />
+        </Link>
+      )
+    },
   },
   {
     id: 'captures-with-detections',
@@ -168,7 +191,9 @@ export const columns = ({
     sticky: true,
     renderCell: (item: CaptureSet) => (
       <Toolbar>
-        {item.canPopulate && <PopulateCaptureSet captureSet={item} />}
+        {item.canPopulate && (
+          <PopulateCaptureSet captureSet={item} compact variant="ghost" />
+        )}
         {item.canUpdate && SERVER_SAMPLING_METHODS.includes(item.method) && (
           <UpdateEntityDialog
             collection={API_ROUTES.CAPTURE_SETS}

--- a/ui/src/pages/project/capture-sets/capture-set-columns.tsx
+++ b/ui/src/pages/project/capture-sets/capture-set-columns.tsx
@@ -53,6 +53,16 @@ export const columns = ({
       type: translate(STRING.ENTITY_TYPE_CAPTURE_SET),
     }),
     renderCell: (item: CaptureSet) => {
+      if (item.currentJob) {
+        return (
+          <StatusTableCell
+            color={item.currentJob.status.color}
+            details={item.currentJob.type.label}
+            label={item.currentJob.status.label}
+          />
+        )
+      }
+
       if (item.canPopulate && item.numImages === 0) {
         return (
           <BasicTableCell>
@@ -61,15 +71,7 @@ export const columns = ({
         )
       }
 
-      return item.currentJob ? (
-        <StatusTableCell
-          color={item.currentJob.status.color}
-          details={item.currentJob.type.label}
-          label={item.currentJob.status.label}
-        />
-      ) : (
-        <></>
-      )
+      return <></>
     },
   },
   {

--- a/ui/src/pages/project/capture-sets/populate-capture-set.tsx
+++ b/ui/src/pages/project/capture-sets/populate-capture-set.tsx
@@ -5,30 +5,38 @@ import { BasicTooltip } from 'design-system/components/tooltip/basic-tooltip'
 import { AlertCircleIcon, Loader2, RefreshCcwIcon } from 'lucide-react'
 import { Button } from 'nova-ui-kit'
 import { STRING, translate } from 'utils/language'
+import { parseServerError } from 'utils/parseServerError/parseServerError'
 
 export const PopulateCaptureSet = ({
   captureSet,
+  compact,
+  variant = 'outline',
 }: {
   captureSet: CaptureSet
+  compact?: boolean
+  variant?: 'ghost' | 'outline'
 }) => {
   const { populateCaptureSet, isLoading, error } = usePopulateCaptureSet()
 
+  const tooltip = (() => {
+    if (error) {
+      return parseServerError(error).message
+    }
+
+    if (compact) {
+      return translate(STRING.POPULATE)
+    }
+  })()
+
   return (
-    <BasicTooltip
-      asChild
-      content={
-        error
-          ? 'Could not populate the capture set, please retry.'
-          : translate(STRING.POPULATE)
-      }
-    >
+    <BasicTooltip asChild content={tooltip}>
       <Button
         aria-label={translate(STRING.POPULATE)}
         className={classNames({ 'text-destructive': error })}
         disabled={isLoading}
         onClick={() => populateCaptureSet(captureSet.id)}
-        size="icon"
-        variant="ghost"
+        size={compact ? 'icon' : 'small'}
+        variant={variant}
       >
         {error ? (
           <AlertCircleIcon className="w-4 h-4" />
@@ -37,6 +45,7 @@ export const PopulateCaptureSet = ({
         ) : (
           <RefreshCcwIcon className="w-4 h-4" />
         )}
+        {!compact ? <span>{translate(STRING.POPULATE)}</span> : null}
       </Button>
     </BasicTooltip>
   )

--- a/ui/src/pages/project/entities/details-form/capture-set-details-form.tsx
+++ b/ui/src/pages/project/entities/details-form/capture-set-details-form.tsx
@@ -370,8 +370,8 @@ export const CaptureSetDetailsForm = ({
           ) : null}
         </FormRow>
         <FormMessage
-          intro={translate(STRING.TIP)}
           message={translate(STRING.MESSAGE_CAPTURE_SET_TIP)}
+          withIcon
         />
       </FormSection>
       <FormActions>

--- a/ui/src/pages/project/entities/details-form/export-details-form.tsx
+++ b/ui/src/pages/project/entities/details-form/export-details-form.tsx
@@ -122,10 +122,7 @@ export const ExportDetailsForm = ({
             </InputContent>
           )}
         />
-        <FormMessage
-          intro={translate(STRING.TIP)}
-          message={translate(STRING.MESSAGE_EXPORT_TIP)}
-        />
+        <FormMessage message={translate(STRING.MESSAGE_EXPORT_TIP)} withIcon />
       </FormSection>
       <FormActions>
         <SaveButton isLoading={isLoading} isSuccess={isSuccess} />

--- a/ui/src/pages/project/entities/details-form/export-details-form.tsx
+++ b/ui/src/pages/project/entities/details-form/export-details-form.tsx
@@ -6,11 +6,10 @@ import {
   FormSection,
 } from 'components/form/layout/layout'
 import { FormConfig } from 'components/form/types'
-import { API_ROUTES } from 'data-services/constants'
 import { Export, SERVER_EXPORT_TYPES } from 'data-services/models/export'
 import { SaveButton } from 'design-system/components/button/save-button'
 import { InputContent } from 'design-system/components/input/input'
-import { EntityPicker } from 'design-system/components/select/entity-picker'
+import { CaptureSetPicker } from 'design-system/components/select/capture-set-picker'
 import { Select } from 'nova-ui-kit'
 import { useForm } from 'react-hook-form'
 import { useParams } from 'react-router-dom'
@@ -75,6 +74,7 @@ export const ExportDetailsForm = ({
         />
       )}
       <FormSection>
+        <FormMessage message={translate(STRING.MESSAGE_EXPORT_TIP)} />
         <FormController
           name="type"
           control={control}
@@ -114,15 +114,13 @@ export const ExportDetailsForm = ({
                 },
               }}
             >
-              <EntityPicker
-                collection={API_ROUTES.CAPTURE_SETS}
+              <CaptureSetPicker
                 onValueChange={field.onChange}
                 value={field.value}
               />
             </InputContent>
           )}
         />
-        <FormMessage message={translate(STRING.MESSAGE_EXPORT_TIP)} withIcon />
       </FormSection>
       <FormActions>
         <SaveButton isLoading={isLoading} isSuccess={isSuccess} />

--- a/ui/src/pages/project/entities/details-form/export-details-form.tsx
+++ b/ui/src/pages/project/entities/details-form/export-details-form.tsx
@@ -115,6 +115,7 @@ export const ExportDetailsForm = ({
               }}
             >
               <CaptureSetPicker
+                clearable
                 onValueChange={field.onChange}
                 value={field.value}
               />

--- a/ui/src/pages/session-details/session-info/session-info.tsx
+++ b/ui/src/pages/session-details/session-info/session-info.tsx
@@ -11,6 +11,10 @@ export const SessionInfo = ({ session }: { session: Session }) => {
 
   const fields = [
     {
+      label: translate(STRING.FIELD_LABEL_ID),
+      value: session.id,
+    },
+    {
       label: translate(STRING.FIELD_LABEL_DEPLOYMENT),
       value: session.deploymentLabel,
       to: APP_ROUTES.DEPLOYMENT_DETAILS({

--- a/ui/src/pages/sessions/session-columns.tsx
+++ b/ui/src/pages/sessions/session-columns.tsx
@@ -46,7 +46,11 @@ export const columns = ({
     name: translate(STRING.FIELD_LABEL_SESSION),
     renderCell: (item: Session) => (
       <Link to={APP_ROUTES.SESSION_DETAILS({ projectId, sessionId: item.id })}>
-        <BasicTableCell value={item.label} theme={CellTheme.Primary} />
+        <BasicTableCell
+          value={item.label}
+          details={[`${translate(STRING.FIELD_LABEL_ID)}: ${item.id}`]}
+          theme={CellTheme.Primary}
+        />
       </Link>
     ),
   },

--- a/ui/src/utils/language.ts
+++ b/ui/src/utils/language.ts
@@ -168,6 +168,8 @@ export enum STRING {
   MESSAGE_CAPTURE_FILENAME,
   MESSAGE_CAPTURE_LIMIT,
   MESSAGE_CAPTURE_SET_FORM_INTRO,
+  MESSAGE_CAPTURE_SET_COUNT,
+  MESSAGE_CAPTURE_SET_EMPTY,
   MESSAGE_CAPTURE_SET_TIP,
   MESSAGE_CAPTURE_SYNC_HIDDEN,
   MESSAGE_CAPTURE_TOO_MANY,
@@ -502,6 +504,8 @@ const ENGLISH_STRINGS: { [key in STRING]: string } = {
     'A maximum of {{numCaptures}} captures for each station can be uploaded through the web browser. Configure a data source to upload data in bulk.',
   [STRING.MESSAGE_CAPTURE_SET_FORM_INTRO]:
     'In this form, you will define the logic for your capture set. When the capture set is defined, it can be populated with captures from the table view.',
+  [STRING.MESSAGE_CAPTURE_SET_COUNT]: 'This will select {{total}} captures.',
+  [STRING.MESSAGE_CAPTURE_SET_EMPTY]: 'This capture set is empty.',
   [STRING.MESSAGE_CAPTURE_SET_TIP]:
     'To define a capture set for all captures, use method "Full" without setting filters.',
   [STRING.MESSAGE_CAPTURE_SYNC_HIDDEN]:

--- a/ui/src/utils/language.ts
+++ b/ui/src/utils/language.ts
@@ -414,7 +414,7 @@ const ENGLISH_STRINGS: { [key in STRING]: string } = {
   [STRING.FIELD_LABEL_FINISHED_AT]: 'Finished at',
   [STRING.FIELD_LABEL_FIRST_DATE]: 'First date',
   [STRING.FIELD_LABEL_FORMAT]: 'Format',
-  [STRING.FIELD_LABEL_GENERAL]: 'General configuration',
+  [STRING.FIELD_LABEL_GENERAL]: 'General',
   [STRING.FIELD_LABEL_ICON]: 'Icon',
   [STRING.FIELD_LABEL_ID]: 'ID',
   [STRING.FIELD_LABEL_IMAGE]: 'Cover image',

--- a/ui/src/utils/language.ts
+++ b/ui/src/utils/language.ts
@@ -526,7 +526,8 @@ const ENGLISH_STRINGS: { [key in STRING]: string } = {
   [STRING.MESSAGE_DELETE_CONFIRM]:
     'Are you sure you want to delete this {{type}}?',
   [STRING.MESSAGE_DRAFTS]: 'Drafts are private and limited to one user.',
-  [STRING.MESSAGE_EXPORT_TIP]: 'To include all captures, skip "Capture set".',
+  [STRING.MESSAGE_EXPORT_TIP]:
+    'We support two export formats: one compact and easy to use, and one that includes all raw data. To include all data in the export, skip "Capture set".',
   [STRING.MESSAGE_HAS_ACCOUNT]: 'Already have an account?',
   [STRING.MESSAGE_IMAGE_FORMAT]: 'Valid formats are PNG, GIF and JPEG.',
   [STRING.MESSAGE_IMAGE_SIZE]:


### PR DESCRIPTION
### Summary of changes
* Add capture set clues to UI
* Render info tooltip in portals to avoid overlap problems
* Expose IDs in UI for captures, stations and sessions
* Update job warning color and link to docs

### Screenshots
<img width="1728" height="1080" alt="Screenshot 2026-04-09 at 10 12 45" src="https://github.com/user-attachments/assets/3480a8c8-3712-44ab-9260-be3a88757734" />
<img width="1728" height="1080" alt="Screenshot 2026-04-09 at 10 12 55" src="https://github.com/user-attachments/assets/14cc6b25-3a28-4733-b562-cb72f0efa715" />
<img width="1728" height="1080" alt="Screenshot 2026-04-09 at 10 13 11" src="https://github.com/user-attachments/assets/2d3b9026-c0a4-415d-b230-ec0ed7cb6215" />
<img width="1728" height="1080" alt="Screenshot 2026-04-09 at 10 13 34" src="https://github.com/user-attachments/assets/d8a94ef5-0bf8-4440-acac-fc6ca200fa30" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ID field display across deployment, session, and capture-set pages.
  * New CaptureSetPicker component for selecting capture sets with clear/empty-state actions.

* **UI/UX Improvements**
  * FormMessage now supports themes (success, warning, destructive) and optional icons; legacy intro prefix removed.
  * Better warnings/guidance for empty/unpopulated capture sets and clearer export instructions.
  * DocsLink adds a chevron indicator.
  * Simplified error styling and removed fixed-width wrappers in project dialogs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->