### PR TITLE
fix(cache): enable SO_KEEPALIVE on django-redis cache connections

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -247,6 +247,27 @@ ANYMAIL = {
 SENDGRID_SANDBOX_MODE_IN_DEBUG = False
 SENDGRID_ECHO_TO_STDOUT = True
 
+# TCP keepalive (shared by Redis cache and Celery/RabbitMQ broker)
+# ------------------------------------------------------------------------------
+# Without SO_KEEPALIVE set on the client socket, the kernel never sends
+# keepalive probes regardless of host-level sysctl tuning. Long-idle pooled
+# connections are then vulnerable to silent drops by stateful cloud firewalls
+# (the failure mode behind #1218, and the trigger for #1073).
+#
+# Default probe schedule: start after 60s idle, retry every 10s, give up
+# after 9 failed attempts -> first dead-connection detection at ~150s.
+#
+# These defaults are safe for all environments: no-ops on localhost
+# (local dev, docker-compose staging/demo), protective anywhere upstream
+# infrastructure can drop idle connections. Production operators can
+# override via env vars if their network needs different tuning (e.g. a
+# more aggressive firewall might warrant a shorter idle).
+TCP_KEEPALIVE_OPTIONS = {
+    socket.TCP_KEEPIDLE: env.int("TCP_KEEPALIVE_IDLE", default=60),
+    socket.TCP_KEEPINTVL: env.int("TCP_KEEPALIVE_INTVL", default=10),
+    socket.TCP_KEEPCNT: env.int("TCP_KEEPALIVE_CNT", default=9),
+}
+
 # CACHES
 # ------------------------------------------------------------------------------
 # https://docs.djangoproject.com/en/dev/ref/settings/#caches
@@ -259,20 +280,14 @@ CACHES = {
             # Mimicing memcache behavior.
             # https://github.com/jazzband/django-redis#memcached-exceptions-behavior
             "IGNORE_EXCEPTIONS": True,
-            # TCP keepalive for pooled connections. Without SO_KEEPALIVE the
-            # kernel never sends probes, regardless of host-level sysctl
-            # tuning, so pooled Redis connections can sit idle long enough
-            # for cloud firewalls to silently drop them. The next task to
-            # borrow such a connection from the pool fails with ECONNRESET.
-            # Values mirror CELERY_BROKER_TRANSPORT_OPTIONS.socket_settings
-            # below. See RolnickLab/antenna#1218.
-            "SOCKET_KEEPALIVE": True,
-            "SOCKET_KEEPALIVE_OPTIONS": {
-                socket.TCP_KEEPIDLE: 60,
-                socket.TCP_KEEPINTVL: 10,
-                socket.TCP_KEEPCNT: 9,
-            },
-            "SOCKET_CONNECT_TIMEOUT": 5,
+            # TCP keepalive -- see TCP_KEEPALIVE_OPTIONS above.
+            "SOCKET_KEEPALIVE": env.bool("REDIS_CACHE_SOCKET_KEEPALIVE", default=True),
+            "SOCKET_KEEPALIVE_OPTIONS": TCP_KEEPALIVE_OPTIONS,
+            # Cap connect-time to fail fast if the Redis host is unreachable,
+            # rather than hanging pooled-connection acquisition indefinitely.
+            # 5s is well above normal connect latency; raise in high-latency
+            # networks.
+            "SOCKET_CONNECT_TIMEOUT": env.int("REDIS_CACHE_SOCKET_CONNECT_TIMEOUT", default=5),
         },
     }
 }
@@ -414,17 +429,10 @@ CELERY_WORKER_CANCEL_LONG_RUNNING_TASKS_ON_CONNECTION_LOSS = True
 # RabbitMQ broker connection settings
 # These settings improve reliability for long-running workers with intermittent network issues
 CELERY_BROKER_TRANSPORT_OPTIONS = {
-    # Custom TCP Keepalives to ensure network stack doesn't silently drop connections
+    # TCP keepalive so the network stack doesn't silently drop connections.
+    # Shared schedule with the Redis cache above -- see TCP_KEEPALIVE_OPTIONS.
     "socket_keepalive": True,
-    "socket_settings": {
-        # Start sending Keepalive packets after 60 seconds of silence.
-        # This forces traffic on the wire, preventing the OpenStack 1-hour timeout.
-        socket.TCP_KEEPIDLE: 60,
-        # If no response, retry every 10 seconds.
-        socket.TCP_KEEPINTVL: 10,
-        # Give up and close connection after 9 failed attempts.
-        socket.TCP_KEEPCNT: 9,
-    },
+    "socket_settings": TCP_KEEPALIVE_OPTIONS,
     # Connection Stability Settings
     "socket_connect_timeout": 40,  # Max time to establish connection
     "retry_on_timeout": True,  # Retry operations if they time out

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -259,6 +259,20 @@ CACHES = {
             # Mimicing memcache behavior.
             # https://github.com/jazzband/django-redis#memcached-exceptions-behavior
             "IGNORE_EXCEPTIONS": True,
+            # TCP keepalive for pooled connections. Without SO_KEEPALIVE the
+            # kernel never sends probes, regardless of host-level sysctl
+            # tuning, so pooled Redis connections can sit idle long enough
+            # for cloud firewalls to silently drop them. The next task to
+            # borrow such a connection from the pool fails with ECONNRESET.
+            # Values mirror CELERY_BROKER_TRANSPORT_OPTIONS.socket_settings
+            # below. See RolnickLab/antenna#1218.
+            "SOCKET_KEEPALIVE": True,
+            "SOCKET_KEEPALIVE_OPTIONS": {
+                socket.TCP_KEEPIDLE: 60,
+                socket.TCP_KEEPINTVL: 10,
+                socket.TCP_KEEPCNT: 9,
+            },
+            "SOCKET_CONNECT_TIMEOUT": 5,
         },
     }
 }


### PR DESCRIPTION
## Summary

Adds TCP keepalive (`SOCKET_KEEPALIVE` + `SOCKET_KEEPALIVE_OPTIONS`) and a connect timeout to `CACHES["default"]["OPTIONS"]` in `config/settings/base.py`, extracts a shared `TCP_KEEPALIVE_OPTIONS` constant so the same tuning is used for both the django-redis cache and the Celery/RabbitMQ broker, and exposes the knobs as env vars so production deployments can tune without a code change.

## Why

`redis-py` does not set `SO_KEEPALIVE` unless the client explicitly opts in via `socket_keepalive=True`. Without it, the kernel never sends TCP keepalive probes on the socket — regardless of host-level sysctl tuning. Pooled Redis connections can sit idle long enough for a stateful cloud firewall to silently drop them; the next task to borrow one from the pool fails with ECONNRESET.

Direct observation on a production worker: `ss -ton state established dport = :6379` showed only some Redis connections with a `timer:(keepalive,...)` entry. The bare ones are the django-redis cache connections this PR fixes.

## Context: how this gap got missed

The TCP-keepalive pattern for Redis/AMQP connections is not new in this repo. Three earlier PRs set it up for Celery-side paths but did not touch the django-redis cache block:

- **#1051** (Nov 2025) — Celery worker memory/task limits; broker pivot from Redis to RabbitMQ. Touched `CELERY_BROKER_TRANSPORT_OPTIONS` only.
- **#1055** (Nov 2025) — Celery result-backend settings. Enabled `CELERY_REDIS_SOCKET_KEEPALIVE` for the Redis result-backend connection pool (distinct from the django-redis cache pool). `CACHES` untouched.
- **#1073** (Dec 2025, direct precursor) — Added `socket_keepalive` + `socket_settings` (TCP_KEEPIDLE=60, TCP_KEEPINTVL=10, TCP_KEEPCNT=9) to `CELERY_BROKER_TRANSPORT_OPTIONS` to fix "zombie Celery tasks" (#1072). Coordinated with host-level sysctl tuning. `CACHES` untouched; the django-redis path was never discussed.

None of the three PR discussions mention the `CACHES` block or any reason not to apply the same tuning there. The omission was by oversight, not a conscious decision — the django-redis cache path uses its own `OPTIONS` dict that doesn't inherit from Celery config.

## What this PR adds

**In `config/settings/base.py`:**

1. A shared `TCP_KEEPALIVE_OPTIONS` constant (60/10/9 defaults, overridable via `TCP_KEEPALIVE_IDLE`, `TCP_KEEPALIVE_INTVL`, `TCP_KEEPALIVE_CNT` env vars) used by **both**:
   - `CACHES["default"]["OPTIONS"]["SOCKET_KEEPALIVE_OPTIONS"]` (new)
   - `CELERY_BROKER_TRANSPORT_OPTIONS["socket_settings"]` (replacing the inline duplicate)

2. `SOCKET_KEEPALIVE: True` on the cache, overridable via `REDIS_CACHE_SOCKET_KEEPALIVE`.

3. `SOCKET_CONNECT_TIMEOUT: 5` on the cache, overridable via `REDIS_CACHE_SOCKET_CONNECT_TIMEOUT`. This caps connect-time so that if the Redis host is briefly unreachable we fail fast rather than blocking the pooled-connection acquisition indefinitely. 5s is well above normal connect latency (noted explicitly because Copilot flagged this as out-of-scope relative to the PR title — it's a small scope addition but intentional and documented in the code).

## Defaults vs. production tuning

The defaults are safe for every environment:

- **local dev, docker-compose, staging, demo** — on localhost the keepalive probes are effectively no-ops; the settings cost nothing.
- **production** — the defaults match what's already in `CELERY_BROKER_TRANSPORT_OPTIONS` and are correct for deployments behind a stateful firewall that drops idle connections after ~1h.

If a deployment has different network behavior (e.g., a more aggressive NAT that drops sooner, or a high-latency link where 5s connect is too tight), operators can override via env:

| Env var | Default | What it does |
|---|---|---|
| `TCP_KEEPALIVE_IDLE` | 60 | Seconds of idle before first keepalive probe |
| `TCP_KEEPALIVE_INTVL` | 10 | Seconds between probes |
| `TCP_KEEPALIVE_CNT` | 9 | Probes before giving up |
| `REDIS_CACHE_SOCKET_KEEPALIVE` | True | Enable/disable keepalive on the cache socket |
| `REDIS_CACHE_SOCKET_CONNECT_TIMEOUT` | 5 | Seconds to wait for connect before failing |

Recommended production baseline is the defaults (first dead-connection detection at ~60s + 9×10s ≈ 150s). Deployments behind a firewall that drops at <60s idle should lower `TCP_KEEPALIVE_IDLE` to roughly half the firewall timeout.

## Incident this addresses

A production `async_api` job was processing normally (hundreds of images processed, results flowing into the database) when one `process_nats_pipeline_result` task hit:

```
Redis error updating job <id> state:
    Error while reading from redis:6379 : (104, 'Connection reset by peer')
```

153 ms later the job was marked FAILURE with "Redis state missing for job" and its NATS stream + Redis state were deleted. Other tasks on the same celery worker reached Redis successfully milliseconds before and after — a single pooled connection had been silently dropped.

The code-path brittleness that escalates a transient Redis blip into a fatal FAILURE is tracked separately in #1219 (reopened). This PR fixes the **config gap** that lets the transient happen in the first place. Both should land.

## Verification after deploy

Inside a celery worker container:

```bash
ss -ton state established dport = :6379
```

Every established Redis connection should show `timer:(keepalive,...)`. Before this change, roughly half were bare.

## What still needs verifying

- Observe `ss -ton` on production workers after deploy to confirm all connections now have keepalive timers.
- Track the rate of "Redis state missing for job" failures over the next ~week; expect it to drop once #1221 and #1219 are both in.
- Consider adding a startup log line that prints the effective `redis-py` connection options so config drift is visible in ops.

## Scope

Hypothesis-driven fix based on code reading + direct `ss` observation. The constant extraction + env tunables also closes a CodeRabbit nit (duplicate dicts between cache and broker keepalive) and the Copilot concern about documenting the connect-timeout choice.

Closes #1218. Related: #1073 (broker precursor), #1219 (code-path fix that pairs with this config fix), #1220.