### PR TITLE
fix(start): allow skipping collectstatic via DISABLE_COLLECTSTATIC env var

### DIFF
--- a/compose/production/django/start
+++ b/compose/production/django/start
@@ -4,7 +4,11 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-python /app/manage.py collectstatic --noinput
+if [ "${DISABLE_COLLECTSTATIC:-0}" = "1" ]; then
+    echo "Skipping collectstatic (DISABLE_COLLECTSTATIC=1)"
+else
+    python /app/manage.py collectstatic --noinput
+fi
 
 # Gunicorn natively reads WEB_CONCURRENCY as its --workers default.
 # If not set, default to CPU core count.


### PR DESCRIPTION
## Summary

Adds an opt-in env var (`DISABLE_COLLECTSTATIC=1`) to skip `collectstatic` in `compose/production/django/start`. Default behaviour is unchanged.

## Why

Deployments that serve static files from an external CDN (e.g. Netlify) do not need Django's `collectstatic` to run on container boot. When the configured `STATICFILES_STORAGE` backend is unreachable, `collectstatic` can hang indefinitely on a network call. Because `/start` runs `collectstatic` before `exec gunicorn`, this blocks gunicorn from ever starting and the container appears "up" but nothing listens on port 5000 — producing 502 Bad Gateway responses upstream until the container is killed and recreated.

This was observed in a production deployment after a routine container restart. The container had been running fine for weeks because the previous image had a local modification commenting out the `collectstatic` line; that modification was lost on the next image rebuild and `collectstatic` ran against an unreachable backend, hanging at boot.

## Behaviour

- `DISABLE_COLLECTSTATIC` unset or set to anything other than `"1"` → unchanged, `collectstatic` runs as before.
- `DISABLE_COLLECTSTATIC=1` → prints `Skipping collectstatic (DISABLE_COLLECTSTATIC=1)` and proceeds straight to gunicorn.

## Test plan

- [ ] Build the production django image, run with `DISABLE_COLLECTSTATIC` unset → confirm `collectstatic` still runs (existing behaviour).
- [ ] Build the production django image, run with `DISABLE_COLLECTSTATIC=1` → confirm the skip message logs and gunicorn starts.
- [ ] No change to local/dev `start` scripts; local development behaviour unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added ability to disable static file collection during application startup via environment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->