### PR TITLE
fix(deps): pin redis-py 5.3.1 to avoid ConnectionPool deadlock

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,7 +2,7 @@ python-slugify==8.0.1  # https://github.com/un33k/python-slugify
 Pillow==10.2.0  # https://github.com/python-pillow/Pillow
 argon2-cffi==21.3.0  # https://github.com/hynek/argon2_cffi
 whitenoise==6.5.0  # https://github.com/evansd/whitenoise
-redis==5.2.1  # https://github.com/redis/redis-py
+redis==5.3.1  # https://github.com/redis/redis-py — pin 5.3.x; 5.2.x deadlocks in ConnectionPool.release (redis-py#3677), 6.x reintroduces it (celery#9622)
 hiredis==2.2.3  # https://github.com/redis/hiredis-py
 celery==5.4.0  # pyup: < 6.0  # https://github.com/celery/celery
 django-celery-beat==2.5.0  # https://github.com/celery/django-celery-beat


### PR DESCRIPTION
## Summary

Bump `redis==5.2.1` → `redis==5.3.1` in `requirements/base.txt`. 5.2.x has a self-deadlock in `ConnectionPool.release()` triggered by `PubSub.__del__` running during GC while the pool holds its non-reentrant `_lock`. Fixed upstream in redis-py 5.3.0 by switching to `RLock` ([redis-py#3677](https://github.com/redis/redis-py/pull/3677)); reintroduced in 6.x per the discussion on [celery/celery#9622](https://github.com/celery/celery/issues/9622), so I'm pinning inside 5.3.x rather than chasing latest.

## Observed failure

Celery beat on a production-like deployment stops scheduling **all** tasks with no error, no crash, no log output. Beat container shows `Up` in docker, but `docker logs celerybeat` has no new lines — indefinitely. Only a manual restart revives it. Observed 4/4 recent job runs.

The `jobs.health_check` periodic task runs every 15 min and is the safety net that reaps stalled async_api jobs when NATS messages go missing. Beat hanging silently disables that safety net, so jobs that have a handful of missing results get stuck in `STARTED` indefinitely and need manual intervention.

## Root cause evidence

Captured via py-spy on a hung beat container. Main thread parked on `futex_wait_queue` inside `ConnectionPool.release()`. Abridged stack:

```
tick()                                   celery/beat.py:353
  apply_entry → apply_async              celery/beat.py:280
    send_task → on_task_call             celery/app/base.py:800
      ResultConsumer.consume_from        celery/backends/redis.py:170
        _consume_from hits ConnErr       celery/backends/redis.py:176
          reconnect_on_error → ensure    celery/backends/redis.py:130
            retry_over_time retries=0    kombu/utils/functional.py:318
              _reconnect_pubsub          celery/backends/redis.py:106
                mget → execute_command   redis/commands/core.py:2009
                  get_connection         redis/connection.py:1417
                    make_connection      redis/connection.py:1463
                      Connection.__init__  redis/connection.py:684
    ⮡ CPython GC fires PubSub.__del__ mid-__init__ ⮣
                        PubSub.__del__      redis/client.py:726
                          PubSub.reset      redis/client.py:734
                            ConnectionPool.release — STUCK   redis/connection.py:1468
```

Every thread (main + library bg threads) is on `futex_wait_queue`. Not an I/O hang — it's a userspace mutex deadlock. The TCP socket to Redis is in `CLOSE-WAIT` with 1 byte in the recv buffer, confirming the Redis server closed its end and the Python client tried to reconnect, which is the code path that deadlocks.

The Redis result backend subscribes to the result key via pubsub inside `on_task_call`, so this fires for every `apply_async` call — including beat's periodic ones. That means every time beat schedules a task, it enters a code path that can deadlock if a stale `PubSub` gets GC'd at the wrong moment. This matches [redis-py#3654](https://github.com/redis/redis-py/issues/3654).

## Why 5.3.1 specifically

- **5.2.x**: has the bug.
- **5.3.0 / 5.3.1**: `self._lock: threading.Lock` → `threading.RLock` in `ConnectionPool` — fix.
- **6.x / 7.x**: per [celery/celery#9622](https://github.com/celery/celery/issues/9622), the lock semantics were reworked again and the same class of issue resurfaced. Reporters on that issue confirmed downgrading to 5.3.x stabilized beat. Worth revisiting when there's a clear fix upstream.

## What this does not do

- Does not upgrade celery / kombu / django-celery-beat. A separate evaluation said 5.5.3 / 5.5.4 / 2.9.0 is a compatible upgrade, but that's orthogonal to this bug and can land separately.
- Does not change the broker heartbeat or `CELERY_BROKER_CONNECTION_MAX_RETRIES`. An earlier hypothesis blamed the AMQP heartbeat churn — the py-spy stack ruled that out, so those knobs stay as-is.

## Test plan

- [x] CI: the pip-compile step picks up the new pin; no `requirements/production.txt` regeneration needed here since it inherits from `base.txt` on build.
- [x] Deploy to a demo environment, run the job pattern that previously hung beat (async_api with ~20-40 min runtime).
- [x] Verify beat keeps emitting `Scheduler: Sending due task` lines through job completion.
- [ ] Re-run py-spy on beat during the job — confirm the main thread is not parked in `ConnectionPool.release()`.
- [x] After job completes, confirm `jobs.health_check` fires on schedule and reaps any remaining stalled entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)