### PR TITLE
feat(ml): filter algorithm list by project pipelines

### DIFF
--- a/ami/ml/tests.py
+++ b/ami/ml/tests.py
@@ -1551,9 +1551,8 @@ class TestAlgorithmViewSetProjectFilter(APITestCase):
         self.client.force_authenticate(user=self.user)
 
     def _list_algorithm_names(self, project_id=None):
-        url = "/api/v2/ml/algorithms/"
-        if project_id is not None:
-            url += f"?project_id={project_id}"
+        params = {"project_id": project_id} if project_id is not None else {}
+        url = reverse_with_params("api:algorithm-list", params=params)
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         return {row["name"] for row in response.json()["results"]}
@@ -1573,3 +1572,14 @@ class TestAlgorithmViewSetProjectFilter(APITestCase):
         self.assertIn("Algo Disabled", names)
         self.assertIn("Algo Other Project", names)
         self.assertIn("Algo Orphan", names)
+
+    def test_detail_endpoint_unscoped_even_with_project_id(self):
+        """Detail stays unscoped so historical classification links still resolve."""
+        url = reverse_with_params(
+            "api:algorithm-detail",
+            kwargs={"pk": self.algo_disabled.pk},
+            params={"project_id": self.project.pk},
+        )
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["name"], "Algo Disabled")

--- a/ami/ml/tests.py
+++ b/ami/ml/tests.py
@@ -1513,3 +1513,63 @@ class TestSaveResultsRefreshesDeploymentCounts(TestCase):
             0,
             "Deployment.taxa_count should reflect taxa from occurrences created by save_results",
         )
+
+
+class TestAlgorithmViewSetProjectFilter(APITestCase):
+    """
+    The algorithm list endpoint is scoped to algorithms belonging to
+    pipelines enabled for the active project.
+    """
+
+    def setUp(self):
+        from ami.ml.models import ProjectPipelineConfig
+
+        self.user = User.objects.create_user(email="algos@example.com", is_staff=True)  # type: ignore
+        self.project = Project.objects.create(name="Algo Project A", create_defaults=False)
+        self.other_project = Project.objects.create(name="Algo Project B", create_defaults=False)
+
+        # Project A: one enabled pipeline, one disabled pipeline
+        self.algo_enabled = Algorithm.objects.create(name="Algo Enabled", version=1)
+        self.algo_disabled = Algorithm.objects.create(name="Algo Disabled", version=1)
+        # Project B: a different pipeline/algorithm
+        self.algo_other_project = Algorithm.objects.create(name="Algo Other Project", version=1)
+        # Unrelated algorithm not attached to any pipeline
+        self.algo_orphan = Algorithm.objects.create(name="Algo Orphan", version=1)
+
+        enabled_pipeline = Pipeline.objects.create(name="Enabled Pipeline")
+        enabled_pipeline.algorithms.add(self.algo_enabled)
+        ProjectPipelineConfig.objects.create(project=self.project, pipeline=enabled_pipeline, enabled=True)
+
+        disabled_pipeline = Pipeline.objects.create(name="Disabled Pipeline")
+        disabled_pipeline.algorithms.add(self.algo_disabled)
+        ProjectPipelineConfig.objects.create(project=self.project, pipeline=disabled_pipeline, enabled=False)
+
+        other_pipeline = Pipeline.objects.create(name="Other Project Pipeline")
+        other_pipeline.algorithms.add(self.algo_other_project)
+        ProjectPipelineConfig.objects.create(project=self.other_project, pipeline=other_pipeline, enabled=True)
+
+        self.client.force_authenticate(user=self.user)
+
+    def _list_algorithm_names(self, project_id=None):
+        url = "/api/v2/ml/algorithms/"
+        if project_id is not None:
+            url += f"?project_id={project_id}"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        return {row["name"] for row in response.json()["results"]}
+
+    def test_lists_only_enabled_pipeline_algorithms_for_project(self):
+        names = self._list_algorithm_names(project_id=self.project.pk)
+        self.assertEqual(names, {"Algo Enabled"})
+
+    def test_other_project_only_sees_its_own_algorithms(self):
+        names = self._list_algorithm_names(project_id=self.other_project.pk)
+        self.assertEqual(names, {"Algo Other Project"})
+
+    def test_unscoped_request_returns_all_algorithms(self):
+        """Without project_id, current behavior lists all algorithms (unchanged)."""
+        names = self._list_algorithm_names()
+        self.assertIn("Algo Enabled", names)
+        self.assertIn("Algo Disabled", names)
+        self.assertIn("Algo Other Project", names)
+        self.assertIn("Algo Orphan", names)

--- a/ami/ml/views.py
+++ b/ami/ml/views.py
@@ -56,12 +56,15 @@ class AlgorithmViewSet(DefaultViewSet, ProjectMixin):
     def get_queryset(self) -> QuerySet["Algorithm"]:
         qs: QuerySet["Algorithm"] = super().get_queryset()
         qs = qs.with_category_count()  # type: ignore[union-attr] # Custom queryset method
-        project = self.get_active_project()
-        if project:
-            qs = qs.filter(
-                pipelines__project_pipeline_configs__project=project,
-                pipelines__project_pipeline_configs__enabled=True,
-            ).distinct()
+        # Only scope list by project. Detail stays unscoped so links from historical
+        # classifications whose pipeline is no longer enabled still resolve.
+        if getattr(self, "action", None) == "list":
+            project = self.get_active_project()
+            if project:
+                qs = qs.filter(
+                    pipelines__project_pipeline_configs__project=project,
+                    pipelines__project_pipeline_configs__enabled=True,
+                ).distinct()
         return qs
 
     @extend_schema(parameters=[project_id_doc_param])

--- a/ami/ml/views.py
+++ b/ami/ml/views.py
@@ -56,7 +56,17 @@ class AlgorithmViewSet(DefaultViewSet, ProjectMixin):
     def get_queryset(self) -> QuerySet["Algorithm"]:
         qs: QuerySet["Algorithm"] = super().get_queryset()
         qs = qs.with_category_count()  # type: ignore[union-attr] # Custom queryset method
+        project = self.get_active_project()
+        if project:
+            qs = qs.filter(
+                pipelines__project_pipeline_configs__project=project,
+                pipelines__project_pipeline_configs__enabled=True,
+            ).distinct()
         return qs
+
+    @extend_schema(parameters=[project_id_doc_param])
+    def list(self, request, *args, **kwargs):
+        return super().list(request, *args, **kwargs)
 
 
 class AlgorithmCategoryMapViewSet(DefaultViewSet):


### PR DESCRIPTION
## Summary

Scope the `/api/v2/ml/algorithms/?project_id=<id>` list to algorithms that belong to pipelines with an enabled `ProjectPipelineConfig` for that project. Previously the endpoint returned every `Algorithm` in the database regardless of `project_id`, while `ml/pipelines/` and `ml/processing_services/` already filtered by project. This aligns the algorithms page at `/projects/<id>/algorithms` with the pipelines and processing services pages.

- `ami/ml/views.py`: `AlgorithmViewSet.get_queryset()` filters by `pipelines__project_pipeline_configs__project=<project>, enabled=True` when a `project_id` is supplied. No filter when omitted, so admin/debug views and the `AlgorithmCategoryMap` cross-reference keep working.
- `AlgorithmViewSet.list()` gets the `project_id_doc_param` schema annotation for parity with the pipeline/processing-service endpoints.
- Detail (`/ml/algorithms/<id>/`) is intentionally left unscoped — clicking an algorithm reference from a classification in a project whose pipeline is no longer enabled still resolves.
- `ami/ml/tests.py`: adds `TestAlgorithmViewSetProjectFilter` covering the enabled-only scoping, isolation between projects, and unchanged behavior when `project_id` is omitted.

## Scope kept deliberately narrow

The user flagged that algorithms can also be referenced from historical classifications on a project whose pipeline has since been disabled. I kept this first pass simple: the list is scoped to *currently enabled* pipelines only, and the detail endpoint stays unscoped so those historical classification links don't 404.

## Follow-up options (not in this PR)

In order of increasing effort / risk, if we want the list to also reflect historical usage:

1. **Include disabled configs.** Drop `enabled=True` so the list shows every pipeline that has *any* `ProjectPipelineConfig` for the project, enabled or not. One-line change. Matches the UX where a disabled pipeline's algorithm still appears because the project has touched it.
2. **Union with pipelines touched by occurrences in the project.** `filter(Q(pipelines__project_pipeline_configs__project=<p>, enabled=True) | Q(classifications__detection__occurrence__project=<p>)).distinct()`. Lets the list surface algorithms that processed data in the project even if the pipeline was never formally configured. The classifications → detection → occurrence join is the expensive piece; worth benchmarking on a project with many occurrences before shipping.
3. **Scope detail endpoint too, with a 'public pipeline' escape hatch.** Treat pipelines attached to >1 project (or a `public` flag) as globally visible; otherwise gate detail on membership in at least one project whose configs include the pipeline. More invasive — needs a policy decision on what 'generally available' means for a pipeline.

Happy to follow up with option 1 or 2 once the team picks a direction.

## Test plan

- [x] New unit tests pass: `docker compose -f docker-compose.ci.yml run --rm django python manage.py test ami.ml.tests.TestAlgorithmViewSetProjectFilter --keepdb`
- [x] `TestProjectPipelinesAPI` still passes (no regression in neighboring project-scoping logic)
- [x] Manual UI check: visit `/projects/<id>/algorithms` on the local stack for a project with both enabled and disabled pipelines; confirm only enabled-pipeline algorithms appear
- [x] Manual check: click through to an algorithm detail page from a classification whose pipeline is disabled in the current project; confirm it still loads

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The algorithms endpoint now supports filtering by `project_id` query parameter, returning only algorithms from pipelines enabled for that specific project.
  * Improved API documentation for project filtering functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->