### PR TITLE
Make tooltip links inside dialogs clickable

### DIFF
--- a/ui/src/design-system/components/info-tooltip.tsx
+++ b/ui/src/design-system/components/info-tooltip.tsx
@@ -18,11 +18,9 @@ export const InfoTooltip = (props: {
           <InfoIcon className="w-4 h-4" />
         </Button>
       </Tooltip.Trigger>
-      <Tooltip.Portal>
-        <Tooltip.Content side="bottom" className="p-4 max-w-xs">
-          <Info {...props} />
-        </Tooltip.Content>
-      </Tooltip.Portal>
+      <Tooltip.Content side="bottom" className="p-4 max-w-xs z-[51]">
+        <Info {...props} />
+      </Tooltip.Content>
     </Tooltip.Root>
   </Tooltip.Provider>
 )


### PR DESCRIPTION
We had a problem where tooltip links were not clickable, but only when used inside dialogs. We fix the problem by skipping the portal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tooltip visibility and stacking order to prevent overlapping issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->