### PR TITLE
feat: assign different categories of background tasks to separate queues

### DIFF
--- a/compose/local/django/celery/worker/start
+++ b/compose/local/django/celery/worker/start
@@ -17,11 +17,12 @@ set -o nounset
 
 MAX_TASKS_PER_CHILD=100
 MAX_MEMORY_PER_CHILD=1048576  # 1 GiB in KB
+QUEUES="${CELERY_QUEUES:-antenna,jobs,ml_results}"
 
 # Launch VS Code debug server if DEBUGGER environment variable is set to 1
 # Note that auto reloading is disabled when debugging, manual restart required for code changes.
 if [ "${DEBUGGER:-0}" = "1" ]; then
-    exec python -Xfrozen_modules=off -m debugpy --listen 0.0.0.0:5679 -m celery -A config.celery_app worker --queues=antenna -l INFO --max-tasks-per-child=$MAX_TASKS_PER_CHILD --max-memory-per-child=$MAX_MEMORY_PER_CHILD
+    exec python -Xfrozen_modules=off -m debugpy --listen 0.0.0.0:5679 -m celery -A config.celery_app worker --queues="$QUEUES" -l INFO --max-tasks-per-child=$MAX_TASKS_PER_CHILD --max-memory-per-child=$MAX_MEMORY_PER_CHILD
 else
-    exec watchfiles --filter python celery.__main__.main --args '-A config.celery_app worker --queues=antenna -l INFO --max-tasks-per-child='$MAX_TASKS_PER_CHILD' --max-memory-per-child='$MAX_MEMORY_PER_CHILD
+    exec watchfiles --filter python celery.__main__.main --args '-A config.celery_app worker --queues='"$QUEUES"' -l INFO --max-tasks-per-child='$MAX_TASKS_PER_CHILD' --max-memory-per-child='$MAX_MEMORY_PER_CHILD
 fi

--- a/compose/production/django/celery/worker/start
+++ b/compose/production/django/celery/worker/start
@@ -6,6 +6,10 @@ set -o nounset
 
 # Production Celery worker with memory leak protections
 #
+# Consumes queues specified by CELERY_QUEUES env var (default: "antenna").
+# Override in compose to run dedicated workers per queue class, e.g.
+# CELERY_QUEUES=ml_results for a worker that only handles ML result tasks.
+#
 # Worker protections:
 # --max-tasks-per-child=100 - Restart worker process after 100 tasks
 # --max-memory-per-child=2097152 - Restart if worker process exceeds 2 GiB (in KB)
@@ -15,5 +19,6 @@ set -o nounset
 
 MAX_TASKS_PER_CHILD=100
 MAX_MEMORY_PER_CHILD=2097152  # 2 GiB in KB
+QUEUES="${CELERY_QUEUES:-antenna}"
 
-exec newrelic-admin run-program celery -A config.celery_app worker --queues=antenna -l INFO --max-tasks-per-child=$MAX_TASKS_PER_CHILD --max-memory-per-child=$MAX_MEMORY_PER_CHILD
+exec newrelic-admin run-program celery -A config.celery_app worker --queues="$QUEUES" -l INFO --max-tasks-per-child=$MAX_TASKS_PER_CHILD --max-memory-per-child=$MAX_MEMORY_PER_CHILD

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -422,6 +422,20 @@ CELERY_REDIS_BACKEND_HEALTH_CHECK_INTERVAL = 30  # Check health every 30s
 CELERY_WORKER_PREFETCH_MULTIPLIER = 1
 CELERY_WORKER_ENABLE_PREFETCH_COUNT_REDUCTION = True
 
+# Split Celery work across three queues so one class of task can't starve
+# another. Each compose file defines a dedicated worker service per queue;
+# see docker-compose.*.yml. Tasks not listed here fall back to the default
+# queue (antenna).
+#
+#   antenna     — default: beat tasks, cache refreshes, sync jobs, misc housekeeping
+#   jobs        — long-running run_job invocations (can hold a slot for hours)
+#   ml_results  — high-volume process_nats_pipeline_result + save_results bursts
+CELERY_TASK_ROUTES = {
+    "ami.jobs.tasks.run_job": {"queue": "jobs"},
+    "ami.jobs.tasks.process_nats_pipeline_result": {"queue": "ml_results"},
+    "ami.ml.models.pipeline.save_results": {"queue": "ml_results"},
+}
+
 # Worker concurrency (prefork pool size)
 # https://docs.celeryq.dev/en/stable/userguide/configuration.html#worker-concurrency
 # Celery's own default when unset is os.cpu_count(), which on the production

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -423,8 +423,9 @@ CELERY_WORKER_PREFETCH_MULTIPLIER = 1
 CELERY_WORKER_ENABLE_PREFETCH_COUNT_REDUCTION = True
 
 # Split Celery work across three queues so one class of task can't starve
-# another. Each compose file defines a dedicated worker service per queue;
-# see docker-compose.*.yml. Tasks not listed here fall back to the default
+# another. Staging/production/worker compose files each run a dedicated
+# worker service per queue; local/CI use a single worker consuming all queues.
+# See docker-compose.*.yml. Tasks not listed here fall back to the default
 # queue (antenna).
 #
 #   antenna     — default: beat tasks, cache refreshes, sync jobs, misc housekeeping

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -429,11 +429,13 @@ CELERY_WORKER_ENABLE_PREFETCH_COUNT_REDUCTION = True
 #
 #   antenna     — default: beat tasks, cache refreshes, sync jobs, misc housekeeping
 #   jobs        — long-running run_job invocations (can hold a slot for hours)
-#   ml_results  — high-volume process_nats_pipeline_result + save_results bursts
+#   ml_results  — high-volume process_nats_pipeline_result + save_results bursts,
+#                 plus create_detection_images (emitted from save_results)
 CELERY_TASK_ROUTES = {
     "ami.jobs.tasks.run_job": {"queue": "jobs"},
     "ami.jobs.tasks.process_nats_pipeline_result": {"queue": "ml_results"},
     "ami.ml.models.pipeline.save_results": {"queue": "ml_results"},
+    "ami.ml.tasks.create_detection_images": {"queue": "ml_results"},
 }
 
 # Worker concurrency (prefork pool size)

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -30,6 +30,26 @@ services:
     scale: 1
     ports: []
     command: /start-celeryworker
+    environment:
+      CELERY_QUEUES: "antenna"
+    restart: always
+
+  celeryworker_jobs:
+    <<: *django
+    scale: 1
+    ports: []
+    command: /start-celeryworker
+    environment:
+      CELERY_QUEUES: "jobs"
+    restart: always
+
+  celeryworker_ml:
+    <<: *django
+    scale: 1
+    ports: []
+    command: /start-celeryworker
+    environment:
+      CELERY_QUEUES: "ml_results"
     restart: always
 
   celerybeat:

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -25,6 +25,10 @@ services:
     scale: 1  # Can't scale until the load balancer is within the compose config
     restart: always
 
+  # Only the antenna (default) queue runs here, alongside beat. The jobs and
+  # ml_results queues are served by dedicated worker hosts (see
+  # docker-compose.worker.yml) so heavy, bursty ML work doesn't compete with
+  # Django/beat for CPU and memory on this box.
   celeryworker:
     <<: *django
     scale: 1
@@ -32,24 +36,6 @@ services:
     command: /start-celeryworker
     environment:
       CELERY_QUEUES: "antenna"
-    restart: always
-
-  celeryworker_jobs:
-    <<: *django
-    scale: 1
-    ports: []
-    command: /start-celeryworker
-    environment:
-      CELERY_QUEUES: "jobs"
-    restart: always
-
-  celeryworker_ml:
-    <<: *django
-    scale: 1
-    ports: []
-    command: /start-celeryworker
-    environment:
-      CELERY_QUEUES: "ml_results"
     restart: always
 
   celerybeat:

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -53,6 +53,26 @@ services:
     scale: 1
     ports: []
     command: /start-celeryworker
+    environment:
+      CELERY_QUEUES: "antenna"
+    restart: always
+
+  celeryworker_jobs:
+    <<: *django
+    scale: 1
+    ports: []
+    command: /start-celeryworker
+    environment:
+      CELERY_QUEUES: "jobs"
+    restart: always
+
+  celeryworker_ml:
+    <<: *django
+    scale: 1
+    ports: []
+    command: /start-celeryworker
+    environment:
+      CELERY_QUEUES: "ml_results"
     restart: always
 
   celerybeat:

--- a/docker-compose.worker.yml
+++ b/docker-compose.worker.yml
@@ -21,14 +21,43 @@ services:
     scale: 0  # We don't need the Django service running, but we inherit the worker settings from it.
     restart: always
 
+  # Dedicated worker hosts carry the heavy jobs and ml_results queues so the
+  # main app host (see docker-compose.production.yml) only serves the
+  # lightweight antenna queue alongside Django/beat.
+  #
+  # Each queue runs in its own container so a burst on one class (e.g.
+  # ml_results fan-out from a big async_api job) cannot saturate the pool and
+  # starve another (e.g. run_job). Every host runs all three services for
+  # capacity; to pin a host to fewer queues, remove services from an override
+  # file or scale them to 0.
+  #
+  # CELERY_WORKER_CONCURRENCY is inherited from .envs/.production/.django and
+  # applies per service. On small worker VMs that adds up (3 × concurrency
+  # prefork processes per host) — tune in the env file if memory pressure
+  # becomes a problem.
   celeryworker:
     <<: *django
-    scale: 1  # 1 worker per machine, celery will scale worker pool to the number of available CPUs.
+    scale: 1
     ports: []
     command: /start-celeryworker
     environment:
-      # Worker hosts (ami-worker-2, ami-worker-3) consume all three queues by
-      # default to add capacity to every pool. To dedicate a worker host to one
-      # queue, override CELERY_QUEUES in its .env file.
-      CELERY_QUEUES: "antenna,jobs,ml_results"
+      CELERY_QUEUES: "antenna"
+    restart: always
+
+  celeryworker_jobs:
+    <<: *django
+    scale: 1
+    ports: []
+    command: /start-celeryworker
+    environment:
+      CELERY_QUEUES: "jobs"
+    restart: always
+
+  celeryworker_ml:
+    <<: *django
+    scale: 1
+    ports: []
+    command: /start-celeryworker
+    environment:
+      CELERY_QUEUES: "ml_results"
     restart: always

--- a/docker-compose.worker.yml
+++ b/docker-compose.worker.yml
@@ -26,4 +26,9 @@ services:
     scale: 1  # 1 worker per machine, celery will scale worker pool to the number of available CPUs.
     ports: []
     command: /start-celeryworker
+    environment:
+      # Worker hosts (ami-worker-2, ami-worker-3) consume all three queues by
+      # default to add capacity to every pool. To dedicate a worker host to one
+      # queue, override CELERY_QUEUES in its .env file.
+      CELERY_QUEUES: "antenna,jobs,ml_results"
     restart: always

--- a/docs/claude/planning/celery-queue-split-rollout.md
+++ b/docs/claude/planning/celery-queue-split-rollout.md
@@ -39,7 +39,7 @@ investigation surfaced.
 
 Goal: validate on demo **without** merging to `main` or running the
 standard deploy flow. Files are scp'd directly onto the demo host; the
-repo is left in a known dirty state that a subsequent `reset_demo_to_branch.sh`
+repo is left in a known dirty state that a subsequent `reset_to_branch.sh`
 will cleanly nuke.
 
 ### Pre-flight (confirm clean window)
@@ -75,7 +75,7 @@ will cleanly nuke.
 
 ### Rollback
 
-`~/reset_demo_to_branch.sh main` restores the deployment branch to `main`,
+`~/reset_to_branch.sh main` restores the deployment branch to `main`,
 wiping our scp'd changes. Demo goes back to single-worker config within
 a few minutes.
 

--- a/docs/claude/planning/celery-queue-split-rollout.md
+++ b/docs/claude/planning/celery-queue-split-rollout.md
@@ -1,0 +1,106 @@
+# Celery queue split — rollout plan
+
+Branch: `feat/celery-queue-split` (commit `f772045b`). Opened against `main`.
+
+## What the change does
+
+Splits Celery tasks across three RabbitMQ queues, each consumed by a
+dedicated worker service, so one class of task cannot starve another:
+
+| Queue        | Tasks                                                    | Rationale                                                                   |
+| ------------ | -------------------------------------------------------- | --------------------------------------------------------------------------- |
+| `antenna`    | default — beat, cache refresh, sync, model_task, misc    | Fast, high-turnover housekeeping                                            |
+| `jobs`       | `run_job`                                                | Can hold a worker slot for hours                                            |
+| `ml_results` | `process_nats_pipeline_result`, `save_results`           | Bursty, ~180 tasks / 5 min per active async_api job                         |
+
+Worker start script is parameterized via `CELERY_QUEUES` env var (default
+`antenna`), so one image serves all three services. `docker-compose.worker.yml`
+(worker-only hosts) consumes all three queues as spillover capacity.
+
+## Why this is needed (motivating incident)
+
+On a demo async_api job of ~740 images, `run_job` invocations for newly
+submitted jobs sat in PENDING for many minutes behind the flood of
+`process_nats_pipeline_result` tasks the first job was emitting. With
+`prefetch_multiplier=1` and concurrency=8, the single worker's slot pool
+was saturated by ML result processing. Splitting gives each class its own
+pool. See issue #1256 for the related JobLog write-path bug this
+investigation surfaced.
+
+## Test plan on the demo environment
+
+Goal: validate on demo **without** merging to `main` or running the
+standard deploy flow. Files are scp'd directly onto the demo host; the
+repo is left in a known dirty state that a subsequent `reset_to_branch.sh`
+will cleanly nuke.
+
+### Pre-flight (confirm clean window)
+
+1. Confirm RabbitMQ `antenna` queue at 0 messages
+2. Confirm NATS streams at 0 pending
+3. Confirm no active jobs in the demo DB (`status not in SUCCESS/FAILURE/REVOKED/CANCELED`)
+
+### Apply changes on demo (no push, no reset script)
+
+1. scp the three changed files onto the demo host:
+   - `config/settings/base.py`
+   - `compose/production/django/celery/worker/start`
+   - `docker-compose.staging.yml` (demo uses the staging compose file)
+2. Rebuild the django image locally on demo:
+   `docker compose -f docker-compose.staging.yml --env-file .envs/.production/.compose build django`
+3. Force-recreate all services using that image:
+   `docker compose ... up -d --force-recreate`
+   (django, celerybeat, flower, celeryworker, celeryworker_jobs, celeryworker_ml)
+
+### Post-deploy verification
+
+- `docker compose ... ps` shows 3 celeryworker containers running
+- `rabbitmqctl list_queues name messages consumers` shows three queues
+  (`antenna`, `jobs`, `ml_results`), each with exactly 1 consumer
+- Trigger a small `run_job` (e.g. a 5-image collection):
+  - Task lands on `jobs` queue (visible in Flower / `list_queues`)
+  - Starts within seconds
+- Trigger an async_api job (~50 images) and watch:
+  - `ml_results` queue fills, drains on its own worker
+  - `antenna` queue stays at ~0, beat tasks still firing on time
+  - A second `run_job` submitted mid-flight starts immediately (not blocked)
+
+### Rollback
+
+`~/reset_demo_to_branch.sh main` restores the deployment branch to `main`,
+wiping our scp'd changes. Demo goes back to single-worker config within
+a few minutes.
+
+## Path to production (after demo validates)
+
+1. Open PR `feat/celery-queue-split` → `main`
+2. Code review (queue routing is a system-level change; at least one
+   reviewer familiar with the Celery topology)
+3. Merge to `main`
+4. Production deploy must update **all three** celery-consuming hosts in
+   this order to avoid unrouted tasks piling up on an unread queue:
+   - First: worker-only hosts (spillover pool consumes all three queues)
+   - Second: ami-live (which adds the dedicated `celeryworker_jobs` and
+     `celeryworker_ml` services)
+5. Post-deploy: same queue / consumer verification as on demo
+
+## Things that could go wrong and how we'd notice
+
+- **Image rebuild fails on demo** — unlikely (change is text-only), but
+  would leave the old container running with the old settings. Visible
+  via `docker compose ps`.
+- **A new queue has zero consumers** — tasks pile up silently. Caught by
+  the "three queues, one consumer each" check above.
+- **Django publisher reads stale routes** — the settings change is read
+  at process start; django container must be recreated alongside the
+  workers (step 3 above handles this).
+- **Beat scheduler uses wrong queue for a scheduled task** — only an
+  issue if a beat task name happens to match a `CELERY_TASK_ROUTES` key.
+  Currently routed tasks (`run_job`, `process_nats_pipeline_result`,
+  `save_results`) are not in the beat schedule, so this shouldn't happen.
+
+## Related
+
+- #1256 — JobLogHandler.emit write-path (the symptom that triggered this
+  investigation)
+- #1026 — concurrent job log updates, complementary to this change

--- a/docs/claude/planning/celery-queue-split-rollout.md
+++ b/docs/claude/planning/celery-queue-split-rollout.md
@@ -7,15 +7,23 @@ Branch: `feat/celery-queue-split` (commit `f772045b`). Opened against `main`.
 Splits Celery tasks across three RabbitMQ queues, each consumed by a
 dedicated worker service, so one class of task cannot starve another:
 
-| Queue        | Tasks                                                    | Rationale                                                                   |
-| ------------ | -------------------------------------------------------- | --------------------------------------------------------------------------- |
-| `antenna`    | default — beat, cache refresh, sync, model_task, misc    | Fast, high-turnover housekeeping                                            |
-| `jobs`       | `run_job`                                                | Can hold a worker slot for hours                                            |
-| `ml_results` | `process_nats_pipeline_result`, `save_results`           | Bursty, ~180 tasks / 5 min per active async_api job                         |
+| Queue        | Tasks                                                                       | Rationale                                           |
+| ------------ | --------------------------------------------------------------------------- | --------------------------------------------------- |
+| `antenna`    | default — beat, cache refresh, sync, misc                                   | Fast, high-turnover housekeeping                    |
+| `jobs`       | `run_job`                                                                   | Can hold a worker slot for hours                    |
+| `ml_results` | `process_nats_pipeline_result`, `save_results`, `create_detection_images`   | Bursty, ~180 tasks / 5 min per active async_api job |
 
 Worker start script is parameterized via `CELERY_QUEUES` env var (default
-`antenna`), so one image serves all three services. `docker-compose.worker.yml`
-(worker-only hosts) consumes all three queues as spillover capacity.
+`antenna`), so one image serves all three services.
+
+**Topology (production):**
+
+- `ami-live` runs only the `antenna` worker (alongside Django + beat + flower).
+  Heavy bursty work is kept off the app host.
+- Dedicated worker hosts (`ami-worker-2`, `ami-worker-3`) run all three
+  services via `docker-compose.worker.yml`. Each queue has its own container
+  on each worker host so a burst on one class cannot saturate the pool and
+  starve another.
 
 ## Why this is needed (motivating incident)
 
@@ -77,12 +85,15 @@ a few minutes.
 2. Code review (queue routing is a system-level change; at least one
    reviewer familiar with the Celery topology)
 3. Merge to `main`
-4. Production deploy must update **all three** celery-consuming hosts in
-   this order to avoid unrouted tasks piling up on an unread queue:
-   - First: worker-only hosts (spillover pool consumes all three queues)
-   - Second: ami-live (which adds the dedicated `celeryworker_jobs` and
-     `celeryworker_ml` services)
-5. Post-deploy: same queue / consumer verification as on demo
+4. Production deploy must update the celery-consuming hosts in this order
+   to avoid unrouted tasks piling up on an unread queue:
+   - First: worker-only hosts (now run three dedicated services — `antenna`,
+     `jobs`, `ml_results`)
+   - Second: ami-live (now runs only the `antenna` worker; the previous
+     single-queue worker is reconfigured to the `antenna` queue only)
+5. Post-deploy: same queue / consumer verification as on demo, but counting
+   consumers across both worker hosts (e.g. `jobs` queue should show 2
+   consumers = one per worker host)
 
 ## Things that could go wrong and how we'd notice
 
@@ -97,7 +108,12 @@ a few minutes.
 - **Beat scheduler uses wrong queue for a scheduled task** — only an
   issue if a beat task name happens to match a `CELERY_TASK_ROUTES` key.
   Currently routed tasks (`run_job`, `process_nats_pipeline_result`,
-  `save_results`) are not in the beat schedule, so this shouldn't happen.
+  `save_results`, `create_detection_images`) are not in the beat schedule,
+  so this shouldn't happen.
+- **Worker VM memory pressure** — splitting the previous single-container
+  worker into three doubles the baseline prefork process count on each VM
+  (3 × `CELERY_WORKER_CONCURRENCY`). Watch RSS after deploy; if memory is
+  tight, lower `CELERY_WORKER_CONCURRENCY` in the worker host `.env`.
 
 ## Related
 

--- a/docs/claude/planning/celery-queue-split-rollout.md
+++ b/docs/claude/planning/celery-queue-split-rollout.md
@@ -1,6 +1,6 @@
 # Celery queue split — rollout plan
 
-Branch: `feat/celery-queue-split` (commit `f772045b`). Opened against `main`.
+Branch: `feat/celery-queue-split`. Opened against `main`.
 
 ## What the change does
 
@@ -18,12 +18,12 @@ Worker start script is parameterized via `CELERY_QUEUES` env var (default
 
 **Topology (production):**
 
-- `ami-live` runs only the `antenna` worker (alongside Django + beat + flower).
+- The app host runs only the `antenna` worker (alongside Django + beat + flower).
   Heavy bursty work is kept off the app host.
-- Dedicated worker hosts (`ami-worker-2`, `ami-worker-3`) run all three
-  services via `docker-compose.worker.yml`. Each queue has its own container
-  on each worker host so a burst on one class cannot saturate the pool and
-  starve another.
+- Dedicated worker hosts run all three services via
+  `docker-compose.worker.yml`. Each queue has its own container on each
+  worker host so a burst on one class cannot saturate the pool and starve
+  another.
 
 ## Why this is needed (motivating incident)
 
@@ -50,7 +50,9 @@ will cleanly nuke.
 
 ### Apply changes on demo (no push, no reset script)
 
-1. scp the three changed files onto the demo host:
+1. scp the files needed for the demo path onto the demo host (the branch
+   also modifies the local and production/worker compose files, but those
+   don't apply to the single-box staging deploy):
    - `config/settings/base.py`
    - `compose/production/django/celery/worker/start`
    - `docker-compose.staging.yml` (demo uses the staging compose file)
@@ -89,7 +91,7 @@ a few minutes.
    to avoid unrouted tasks piling up on an unread queue:
    - First: worker-only hosts (now run three dedicated services — `antenna`,
      `jobs`, `ml_results`)
-   - Second: ami-live (now runs only the `antenna` worker; the previous
+   - Second: the app host (now runs only the `antenna` worker; the previous
      single-queue worker is reconfigured to the `antenna` queue only)
 5. Post-deploy: same queue / consumer verification as on demo, but counting
    consumers across both worker hosts (e.g. `jobs` queue should show 2

--- a/docs/claude/planning/celery-queue-split-rollout.md
+++ b/docs/claude/planning/celery-queue-split-rollout.md
@@ -39,7 +39,7 @@ investigation surfaced.
 
 Goal: validate on demo **without** merging to `main` or running the
 standard deploy flow. Files are scp'd directly onto the demo host; the
-repo is left in a known dirty state that a subsequent `reset_to_branch.sh`
+repo is left in a known dirty state that a subsequent `reset_demo_to_branch.sh`
 will cleanly nuke.
 
 ### Pre-flight (confirm clean window)


### PR DESCRIPTION
## Summary

Splits Celery tasks across three dedicated queues so one class of task cannot starve another:

| Queue        | Tasks                                                                       | Rationale                                           |
| ------------ | --------------------------------------------------------------------------- | --------------------------------------------------- |
| `antenna`    | default — beat, cache refresh, sync, misc                                   | Fast, high-turnover housekeeping                    |
| `jobs`       | `run_job`                                                                   | Can hold a worker slot for hours                    |
| `ml_results` | `process_nats_pipeline_result`, `save_results`, `create_detection_images`   | Bursty, ~180 tasks / 5 min per active async_api job |

Worker start script is parameterized via `CELERY_QUEUES` (default differs per script), so one image serves all three services.

## Topology

- **App host** (production): runs only the `antenna` worker, alongside Django + beat + flower. Heavy bursty work is kept off the app host so the ML pool doesn't compete with request handling for CPU/RAM.
- **Dedicated worker hosts** (production): run all three services (`antenna`, `jobs`, `ml_results`) via `docker-compose.worker.yml`. Each queue gets its own container on each worker host so a burst on one class cannot saturate a shared pool and starve another.
- **Staging**: single-host deploy runs all three worker services on one box.
- **Local dev / CI**: a single `celeryworker` consumes all three queues (`CELERY_QUEUES` default in `compose/local/django/celery/worker/start` is `antenna,jobs,ml_results`). No per-queue services needed — this is why existing tests continue to pass without compose changes for CI.

## Motivation

On a production async_api job of ~740 images, `run_job` invocations for newly submitted jobs sat in PENDING for many minutes behind the flood of `process_nats_pipeline_result` tasks the first job was emitting. With `prefetch_multiplier=1` and `concurrency=8`, a single worker's slot pool was saturated by ML result processing. Splitting gives each class its own pool.

## Validation

Deployed and tested on both preview environments (single-host, three workers each).

**Staging** (integration branch — queue split + pgbouncer + main):
- `rabbitmqctl list_queues` shows `antenna`, `jobs`, `ml_results` with 1 consumer each, idle at 0 between dispatches
- `app.amqp.router` resolves `run_job → jobs`, `process_nats_pipeline_result → ml_results`, `save_results → ml_results`, `create_detection_images → ml_results`, default → `antenna`
- `test_ml_job_e2e` async_api job (20 images, panama pipeline): 24s end-to-end, all three stages SUCCESS
- Beat tasks continued flowing on `antenna` while the job occupied `ml_results`

**Demo** (queue split alone):
- Same queue / consumer topology check passed
- `test_ml_job_e2e` async_api job (10 images, quebec pipeline): 18s end-to-end, all three stages SUCCESS
- Larger load test with multi-hundred-image async_api job also ran clean

## Test plan

- [x] Local single-worker validation (all three queues consumed by one container)
- [x] Staging deploy — three workers, three queues, one consumer each; e2e async_api job SUCCESS
- [x] Demo deploy — same verification, independent env
- [x] Demo load test with a larger job (to stress-test isolation, not just routing)
- [x] Code review (queue routing is a system-level change; at least one reviewer familiar with the Celery topology)
- [ ] Production rollout (see below)

## Path to production

Deploy order matters so tasks don't pile up on an unread queue:

1. **First**: worker-only hosts. `docker-compose.worker.yml` now runs three services — deploying here first ensures every queue has a consumer before the app host stops serving the old ones.
2. **Second**: app host. `docker-compose.production.yml` now runs only the `antenna` worker; the previous single-queue worker is reconfigured to the `antenna` queue.

Post-deploy verification:
- `rabbitmqctl list_queues name messages consumers` shows three queues, each with at least 1 consumer (2 = one per worker host, for `jobs` and `ml_results`)
- Flower shows `celeryworker_jobs` and `celeryworker_ml` containers only on worker hosts, not on the app host
- A small `run_job` starts within seconds even during async_api result bursts

## Things that could go wrong

- **A new queue has zero consumers** — tasks pile up silently at the broker. Mitigated by the deploy order above and the "≥1 consumer each" post-deploy check. `check_stale_jobs` (beat task, `STALLED_JOBS_MAX_MINUTES` cutoff) will also catch a never-consumed `run_job` since `PENDING` is in `JobState.running_states()`, so a truly stuck job eventually gets revoked and surfaced in the UI.
- **Django publisher reads stale routes** — the settings change is read at process start; django container must be recreated alongside the workers.
- **Beat scheduler uses wrong queue for a scheduled task** — only an issue if a beat task name happens to match a `CELERY_TASK_ROUTES` key. Currently routed tasks are not in the beat schedule.
- **Worker VM memory pressure** — splitting the previous single-container worker into three triples the baseline prefork process count on each VM (3 × `CELERY_WORKER_CONCURRENCY`). Watch RSS after deploy; lower `CELERY_WORKER_CONCURRENCY` in the worker host `.env` if memory is tight.

## Follow-ups (deferred)

- **Active consumer-count monitor** — a beat task that calls `rabbitmqctl list_queues name consumers` (or the management API) every N minutes and emits an error log when any of `antenna`/`jobs`/`ml_results` has 0 consumers. Would shave the detection window for "worker host flapped" scenarios without waiting for `check_stale_jobs` to fire.