### PR TITLE
fix(grouping): cap event duration at 24h for continuous-monitoring deployments

### DIFF
--- a/ami/main/management/commands/seed_synthetic_occurrences.py
+++ b/ami/main/management/commands/seed_synthetic_occurrences.py
@@ -1,0 +1,144 @@
+"""
+Seed synthetic Detections + Occurrences against an existing deployment so the
+24h-cap regrouping path can be exercised on staging without running an ML
+pipeline.
+
+Each SourceImage in the deployment gets one Detection. Each Detection gets one
+Occurrence (event=None, determination=None). After seeding, run
+``group_images_into_events`` against the deployment with
+``max_event_duration=timedelta(hours=24)`` and verify that
+``Occurrence.event_id`` is populated correctly via the realignment Subquery.
+
+Usage:
+    docker compose exec django python manage.py seed_synthetic_occurrences \
+        --deployment <id> [--limit 5000] [--batch-size 1000] [--clean]
+"""
+
+import datetime
+
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+
+from ami.main.models import Deployment, Detection, Occurrence, SourceImage
+
+
+class Command(BaseCommand):
+    help = "Create synthetic Detections + Occurrences for a deployment to test event_id realignment."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--deployment", type=int, required=True, help="Deployment PK")
+        parser.add_argument(
+            "--limit",
+            type=int,
+            default=None,
+            help="Max number of SourceImages to seed against (default: all)",
+        )
+        parser.add_argument("--batch-size", type=int, default=1000)
+        parser.add_argument(
+            "--clean",
+            action="store_true",
+            help="Delete synthetic Detections + Occurrences for this deployment instead of creating",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Print counts without writing",
+        )
+
+    def handle(self, *args, **opts):
+        try:
+            deployment = Deployment.objects.get(pk=opts["deployment"])
+        except Deployment.DoesNotExist as exc:
+            raise CommandError(f"Deployment {opts['deployment']} not found") from exc
+
+        if opts["clean"]:
+            self._clean(deployment, dry_run=opts["dry_run"])
+            return
+
+        self._seed(
+            deployment=deployment,
+            limit=opts["limit"],
+            batch_size=opts["batch_size"],
+            dry_run=opts["dry_run"],
+        )
+
+    def _seed(self, deployment: Deployment, limit: int | None, batch_size: int, dry_run: bool) -> None:
+        qs = SourceImage.objects.filter(deployment=deployment).order_by("pk")
+        if limit:
+            qs = qs[:limit]
+
+        total = qs.count()
+        if not total:
+            self.stdout.write(self.style.WARNING(f"No SourceImages on deployment {deployment.pk}"))
+            return
+
+        self.stdout.write(
+            f"Seeding {total} SourceImages on deployment {deployment.pk} "
+            f"({deployment.project_id=}) in batches of {batch_size}"
+        )
+        if dry_run:
+            self.stdout.write(self.style.WARNING("Dry run; no writes."))
+            return
+
+        created_detections = 0
+        created_occurrences = 0
+        for offset in range(0, total, batch_size):
+            batch = list(qs[offset : offset + batch_size].values("pk", "timestamp"))
+            with transaction.atomic():
+                occurrences = Occurrence.objects.bulk_create(
+                    [
+                        Occurrence(
+                            project_id=deployment.project_id,
+                            deployment_id=deployment.pk,
+                            event=None,
+                            determination=None,
+                        )
+                        for _ in batch
+                    ]
+                )
+                detections = [
+                    Detection(
+                        source_image_id=row["pk"],
+                        timestamp=row["timestamp"],
+                        bbox=[10, 10, 20, 20],
+                        occurrence_id=occ.pk,
+                    )
+                    for row, occ in zip(batch, occurrences)
+                ]
+                Detection.objects.bulk_create(detections)
+            created_occurrences += len(occurrences)
+            created_detections += len(detections)
+            self.stdout.write(f"  ...batch {offset // batch_size + 1}: {len(batch)} rows")
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Created {created_detections} Detections + {created_occurrences} Occurrences "
+                f"on deployment {deployment.pk}. Now run group_images_into_events with "
+                f"max_event_duration={datetime.timedelta(hours=24)} and confirm event_id realignment."
+            )
+        )
+
+    def _clean(self, deployment: Deployment, dry_run: bool) -> None:
+        synthetic_dets = Detection.objects.filter(
+            source_image__deployment=deployment,
+            bbox=[10, 10, 20, 20],
+            detection_algorithm__isnull=True,
+            path__isnull=True,
+        )
+        synthetic_occ_ids = list(
+            synthetic_dets.exclude(occurrence__isnull=True).values_list("occurrence_id", flat=True).distinct()
+        )
+
+        det_count = synthetic_dets.count()
+        occ_count = Occurrence.objects.filter(pk__in=synthetic_occ_ids).count()
+
+        self.stdout.write(
+            f"Would delete {det_count} synthetic Detections + {occ_count} Occurrences on deployment {deployment.pk}"
+        )
+        if dry_run:
+            return
+
+        with transaction.atomic():
+            synthetic_dets.delete()
+            Occurrence.objects.filter(pk__in=synthetic_occ_ids).delete()
+        self.stdout.write(self.style.SUCCESS("Cleaned."))

--- a/ami/main/models.py
+++ b/ami/main/models.py
@@ -1496,7 +1496,7 @@ def group_images_into_events(
     deployment_occurrences.update(
         event_id=models.Subquery(
             Detection.objects.filter(occurrence_id=models.OuterRef("pk"))
-            .order_by("source_image__timestamp")
+            .order_by("source_image__timestamp", "source_image_id", "pk")
             .values("source_image__event_id")[:1]
         )
     )

--- a/ami/main/models.py
+++ b/ami/main/models.py
@@ -1477,6 +1477,33 @@ def group_images_into_events(
         f"Done grouping {len(image_timestamps)} captures into {len(events)} events " f"for deployment {deployment}"
     )
 
+    # Realign Occurrence.event_id with each occurrence's detections' current
+    # source_image.event_id. Occurrences are bound to an event once at creation
+    # time (Detection.associate_new_occurrence and Pipeline.save_results both
+    # read source_image.event), and are never re-derived afterward. Without
+    # this refresh, a deployment regrouped under the 24h cap keeps every
+    # occurrence pointing at its original (pre-cap) event regardless of when
+    # its detections actually fired — breaking every Occurrence.event-keyed
+    # query (the occur_det_proj_evt index, Event.occurrences related-name,
+    # event_ids= filters at models.py:4232–4477). Track the events currently
+    # held by occurrences in this deployment before and after the refresh so
+    # update_calculated_fields_for_events below picks up both losers and
+    # gainers of occurrences when it recomputes occurrences_count.
+    deployment_occurrences = Occurrence.objects.filter(deployment=deployment)
+    touched_event_pks.update(
+        deployment_occurrences.exclude(event__isnull=True).values_list("event_id", flat=True).distinct()
+    )
+    deployment_occurrences.update(
+        event_id=models.Subquery(
+            Detection.objects.filter(occurrence_id=models.OuterRef("pk"))
+            .order_by("source_image__timestamp")
+            .values("source_image__event_id")[:1]
+        )
+    )
+    touched_event_pks.update(
+        deployment_occurrences.exclude(event__isnull=True).values_list("event_id", flat=True).distinct()
+    )
+
     # Refresh cached fields on every event touched by grouping. An event reused
     # via matching group_by can lose captures to new events created by later
     # iterations above, leaving its start/end/captures_count stale — e.g. a
@@ -1494,9 +1521,14 @@ def group_images_into_events(
         logger.info(f"Setting image dimensions for event {event}")
         set_dimensions_for_collection(event)
 
-    logger.info("Updating relevant cached fields on deployment")
-    deployment.events_count = len(events)
-    deployment.save(update_calculated_fields=False, update_fields=["events_count"])
+    # Refresh deployment-level cached counts. The async regroup_events task
+    # never goes through Deployment.save's calculated-fields refresh, so
+    # without this call the deployment list (occurrences_count, taxa_count,
+    # etc.) keeps showing pre-regroup numbers until the next save touches it.
+    # The save inside update_calculated_fields uses update_calculated_fields=False
+    # so it doesn't re-enter the regroup path.
+    logger.info("Updating cached fields on deployment")
+    deployment.update_calculated_fields(save=True)
 
     audit_event_lengths(deployment)
 

--- a/ami/main/models.py
+++ b/ami/main/models.py
@@ -1389,8 +1389,14 @@ def audit_event_lengths(deployment: Deployment):
         logger.error(f"Found {events_ending_before_start} event(s) with start > end in deployment {deployment}")
 
 
+DEFAULT_MAX_EVENT_DURATION = datetime.timedelta(hours=24)
+
+
 def group_images_into_events(
-    deployment: Deployment, max_time_gap=datetime.timedelta(minutes=120), delete_empty=True
+    deployment: Deployment,
+    max_time_gap=datetime.timedelta(minutes=120),
+    delete_empty=True,
+    max_event_duration: datetime.timedelta | None = DEFAULT_MAX_EVENT_DURATION,
 ) -> list[Event]:
     # Log a warning if multiple SourceImages have the same timestamp
     dupes = (
@@ -1417,9 +1423,11 @@ def group_images_into_events(
         .distinct()
     )
 
-    timestamp_groups = ami.utils.dates.group_datetimes_by_gap(image_timestamps, max_time_gap)
-    # @TODO this event grouping needs testing. Still getting events over 24 hours
-    # timestamp_groups = ami.utils.dates.group_datetimes_by_shifted_day(image_timestamps)
+    timestamp_groups = ami.utils.dates.group_datetimes_by_gap(
+        image_timestamps,
+        max_time_gap,
+        max_event_duration=max_event_duration,
+    )
 
     events = []
     for group in timestamp_groups:

--- a/ami/main/models.py
+++ b/ami/main/models.py
@@ -1430,6 +1430,7 @@ def group_images_into_events(
     )
 
     events = []
+    touched_event_pks: set[int] = set()
     for group in timestamp_groups:
         if not len(group):
             continue
@@ -1453,6 +1454,18 @@ def group_images_into_events(
             defaults={"start": start_date, "end": end_date},
         )
         events.append(event)
+        touched_event_pks.add(event.pk)
+
+        # Track events currently holding these captures — they'll lose captures
+        # to the UPDATE below and need their cached fields refreshed at the end.
+        touched_event_pks.update(
+            SourceImage.objects.filter(deployment=deployment, timestamp__in=group)
+            .exclude(event__isnull=True)
+            .exclude(event=event)
+            .values_list("event_id", flat=True)
+            .distinct()
+        )
+
         SourceImage.objects.filter(deployment=deployment, timestamp__in=group).update(event=event)
         event.save()  # Update start and end times and other cached fields
         logger.info(
@@ -1463,6 +1476,14 @@ def group_images_into_events(
     logger.info(
         f"Done grouping {len(image_timestamps)} captures into {len(events)} events " f"for deployment {deployment}"
     )
+
+    # Refresh cached fields on every event touched by grouping. An event reused
+    # via matching group_by can lose captures to new events created by later
+    # iterations above, leaving its start/end/captures_count stale — e.g. a
+    # pre-existing multi-month event being re-grouped under a 24h cap.
+    # (#904 is expected to rework this reuse path more thoroughly.)
+    if touched_event_pks:
+        update_calculated_fields_for_events(pks=list(touched_event_pks))
 
     if delete_empty:
         logger.info("Deleting empty events for deployment")

--- a/ami/main/models.py
+++ b/ami/main/models.py
@@ -1485,7 +1485,7 @@ def group_images_into_events(
     # occurrence pointing at its original (pre-cap) event regardless of when
     # its detections actually fired — breaking every Occurrence.event-keyed
     # query (the occur_det_proj_evt index, Event.occurrences related-name,
-    # event_ids= filters at models.py:4232–4477). Track the events currently
+    # event_ids= filters at models.py:4232-4477). Track the events currently
     # held by occurrences in this deployment before and after the refresh so
     # update_calculated_fields_for_events below picks up both losers and
     # gainers of occurrences when it recomputes occurrences_count.

--- a/ami/main/tests.py
+++ b/ami/main/tests.py
@@ -236,26 +236,29 @@ class TestImageGrouping(TestCase):
         for event in events:
             assert event.captures.count() == images_per_night
 
-    def test_continuous_monitoring_capped_at_24_hours(self):
-        """
-        A deployment that captures images continuously (no gap > max_time_gap)
-        should still be broken into daily events by the max_event_duration cap,
-        not coalesced into one multi-day event.
-        """
+    def _populate_continuous_captures(self, days: int = 3, interval_minutes: int = 10):
+        """Create ``days`` of gap-free captures (no gap > ``interval_minutes``)."""
         import pathlib
         import uuid
 
         start = datetime.datetime(2023, 4, 24, 3, 22, 38)
-        # 3 days of images every 10 minutes — no gap ever exceeds max_time_gap
-        interval = datetime.timedelta(minutes=10)
-        total_span = datetime.timedelta(days=3)
-        count = int(total_span / interval)
+        interval = datetime.timedelta(minutes=interval_minutes)
+        count = int(datetime.timedelta(days=days) / interval)
         for i in range(count):
             SourceImage.objects.create(
                 deployment=self.deployment,
                 timestamp=start + i * interval,
                 path=pathlib.Path("test") / f"{uuid.uuid4().hex[:8]}_continuous_{i}.jpg",
             )
+        return count
+
+    def test_continuous_monitoring_capped_at_24_hours(self):
+        """
+        A deployment that captures images continuously (no gap > max_time_gap)
+        should still be broken into daily events by the max_event_duration cap,
+        not coalesced into one multi-day event.
+        """
+        self._populate_continuous_captures(days=3, interval_minutes=10)
 
         events = group_images_into_events(
             deployment=self.deployment,
@@ -267,6 +270,53 @@ class TestImageGrouping(TestCase):
         for event in events:
             duration = event.end - event.start
             assert duration <= datetime.timedelta(hours=24), f"event {event.pk} spans {duration}, exceeds 24h cap"
+
+    def test_regrouping_existing_long_event_refreshes_cached_fields(self):
+        """
+        Regression test for the regroup-existing-events path: a deployment
+        already grouped into a single multi-day event should, after re-running
+        grouping with the 24h cap, end up with no events exceeding 24h AND
+        every reused event's cached start/end/captures_count must reflect its
+        current captures (not its pre-regroup state).
+
+        This is narrower than #904's refactor on purpose: it asserts the
+        observable cap+refresh behavior without depending on the specific
+        group_by reuse mechanics that #904 is expected to remove.
+        """
+        total_captures = self._populate_continuous_captures(days=3, interval_minutes=10)
+
+        # First pass with the cap disabled → a single multi-day "mega-event".
+        events_uncapped = group_images_into_events(
+            deployment=self.deployment,
+            max_time_gap=datetime.timedelta(hours=2),
+            max_event_duration=None,
+        )
+        assert len(events_uncapped) == 1
+        mega_event = events_uncapped[0]
+        assert (mega_event.end - mega_event.start) > datetime.timedelta(hours=24)
+
+        # Second pass with the cap → must split the mega-event and refresh
+        # cached fields on the reused event.
+        group_images_into_events(
+            deployment=self.deployment,
+            max_time_gap=datetime.timedelta(hours=2),
+            max_event_duration=datetime.timedelta(hours=24),
+        )
+
+        all_events = Event.objects.filter(deployment=self.deployment)
+        assert all_events.count() >= 3
+
+        for event in all_events:
+            duration = event.end - event.start
+            assert duration <= datetime.timedelta(
+                hours=24
+            ), f"event {event.pk} spans {duration} after regroup; cached fields are stale"
+
+        total_assigned = sum(e.captures_count for e in all_events)
+        assert total_assigned == total_captures, (
+            f"captures_count across events ({total_assigned}) does not match total captures ({total_captures}); "
+            f"cached counters did not refresh after reassignment"
+        )
 
     def test_pruning_empty_events(self):
         from ami.main.models import delete_empty_events

--- a/ami/main/tests.py
+++ b/ami/main/tests.py
@@ -330,6 +330,103 @@ class TestImageGrouping(TestCase):
             f"captures were orphaned during regroup"
         )
 
+    def test_regrouping_realigns_occurrence_event_id(self):
+        """
+        Regression test for stale ``Occurrence.event_id`` after regroup.
+
+        Occurrences are bound to an event once at creation time (from
+        ``detection.source_image.event``). When the 24h cap runs against a
+        deployment that already has detections + occurrences attached to a
+        single mega-event, the source_images are reassigned but the
+        occurrences' event_ids stay stuck at the mega-event unless we
+        explicitly realign them. This test asserts the realignment plus the
+        downstream ``occurrences_count`` consistency on the daily events.
+        """
+        self._populate_continuous_captures(days=3, interval_minutes=10)
+        captures = list(SourceImage.objects.filter(deployment=self.deployment).order_by("timestamp"))
+        captures_per_day = len(captures) // 3
+
+        # First pass with the cap disabled → one mega-event holding everything.
+        group_images_into_events(
+            deployment=self.deployment,
+            max_time_gap=datetime.timedelta(hours=2),
+            max_event_duration=None,
+        )
+        mega_event = Event.objects.get(deployment=self.deployment)
+
+        # One occurrence per day, attached to a capture from that day.
+        # Indices: 0 → day 0, captures_per_day → day 1, 2 * captures_per_day → day 2.
+        targets = [captures[0], captures[captures_per_day], captures[2 * captures_per_day]]
+        occurrences = []
+        for capture in targets:
+            detection = Detection.objects.create(
+                source_image=capture,
+                timestamp=capture.timestamp,
+                bbox=[0.1, 0.1, 0.2, 0.2],
+            )
+            occurrence = Occurrence.objects.create(
+                event=mega_event,
+                deployment=self.deployment,
+                project=self.project,
+            )
+            detection.occurrence = occurrence
+            detection.save()
+            occurrences.append(occurrence)
+
+        # Sanity: all three occurrences point at the mega-event before regroup.
+        for occurrence in occurrences:
+            occurrence.refresh_from_db()
+            assert occurrence.event_id == mega_event.pk
+
+        # Second pass: 24h cap → 3 daily events, each occurrence must follow
+        # its detection's source_image into the corresponding daily event.
+        group_images_into_events(
+            deployment=self.deployment,
+            max_time_gap=datetime.timedelta(hours=2),
+            max_event_duration=datetime.timedelta(hours=24),
+        )
+
+        for occurrence in occurrences:
+            occurrence.refresh_from_db()
+            first_detection = (
+                Detection.objects.filter(occurrence=occurrence)
+                .select_related("source_image")
+                .order_by("source_image__timestamp")
+                .first()
+            )
+            assert first_detection is not None
+            expected_event_id = first_detection.source_image.event_id
+            assert occurrence.event_id == expected_event_id, (
+                f"occurrence {occurrence.pk}: stale event_id={occurrence.event_id} "
+                f"(expected {expected_event_id} from first detection's source_image)"
+            )
+
+        # Realignment must also have moved occurrences across events, not just
+        # left them all on the (reused) day-0 event. With detections on captures
+        # 0, captures_per_day, and 2*captures_per_day, the 24h cap should put
+        # at least one occurrence on a non-day-0 event.
+        non_day0_events = Event.objects.filter(deployment=self.deployment).exclude(
+            pk=Occurrence.objects.filter(pk=occurrences[0].pk).values("event_id")[:1]
+        )
+        assert Occurrence.objects.filter(event__in=non_day0_events).count() >= 1
+
+        # Each daily event's cached ``occurrences_count`` must match the live
+        # computation that ``update_calculated_fields`` itself uses (which
+        # applies the project's default filters). Catches the case where
+        # occurrences moved off an event but its cached counter wasn't
+        # refreshed because the event wasn't tracked as touched.
+        daily_events = Event.objects.filter(deployment=self.deployment)
+        assert daily_events.count() == 3
+        for event in daily_events:
+            expected = event.get_occurrences_count()
+            assert event.occurrences_count == expected, (
+                f"event {event.pk} cached occurrences_count={event.occurrences_count} "
+                f"!= live get_occurrences_count()={expected}; cached counter is stale"
+            )
+
+        # No occurrence should be left pointing at a deleted/missing event.
+        assert Occurrence.objects.filter(deployment=self.deployment, event__isnull=True).count() == 0
+
     def test_pruning_empty_events(self):
         from ami.main.models import delete_empty_events
 

--- a/ami/main/tests.py
+++ b/ami/main/tests.py
@@ -266,7 +266,9 @@ class TestImageGrouping(TestCase):
             max_event_duration=datetime.timedelta(hours=24),
         )
 
-        assert len(events) >= 3, f"expected at least 3 daily events, got {len(events)}"
+        # 3 days × 24h / 10min = 432 captures; capped at 24h → exactly 3 events.
+        # `== 3` (not `>= 3`) guards against over-splitting regressions too.
+        assert len(events) == 3, f"expected exactly 3 daily events, got {len(events)}"
         for event in events:
             duration = event.end - event.start
             assert duration <= datetime.timedelta(hours=24), f"event {event.pk} spans {duration}, exceeds 24h cap"
@@ -304,7 +306,7 @@ class TestImageGrouping(TestCase):
         )
 
         all_events = Event.objects.filter(deployment=self.deployment)
-        assert all_events.count() >= 3
+        assert all_events.count() == 3, f"expected exactly 3 events after regroup, got {all_events.count()}"
 
         for event in all_events:
             duration = event.end - event.start
@@ -312,10 +314,20 @@ class TestImageGrouping(TestCase):
                 hours=24
             ), f"event {event.pk} spans {duration} after regroup; cached fields are stale"
 
+            # Per-event cached-count check: catches reused events whose captures_count
+            # was never refreshed after captures were reassigned away. A sum-only check
+            # can miss this when two events' errors offset each other.
+            actual_captures = SourceImage.objects.filter(event=event).count()
+            assert event.captures_count == actual_captures, (
+                f"event {event.pk} cached captures_count={event.captures_count} "
+                f"does not match actual related count={actual_captures}; cached counters are stale"
+            )
+
+        # Orphan check: every capture must belong to some event.
         total_assigned = sum(e.captures_count for e in all_events)
         assert total_assigned == total_captures, (
             f"captures_count across events ({total_assigned}) does not match total captures ({total_captures}); "
-            f"cached counters did not refresh after reassignment"
+            f"captures were orphaned during regroup"
         )
 
     def test_pruning_empty_events(self):

--- a/ami/main/tests.py
+++ b/ami/main/tests.py
@@ -344,7 +344,6 @@ class TestImageGrouping(TestCase):
         """
         self._populate_continuous_captures(days=3, interval_minutes=10)
         captures = list(SourceImage.objects.filter(deployment=self.deployment).order_by("timestamp"))
-        captures_per_day = len(captures) // 3
 
         # First pass with the cap disabled → one mega-event holding everything.
         group_images_into_events(
@@ -354,9 +353,18 @@ class TestImageGrouping(TestCase):
         )
         mega_event = Event.objects.get(deployment=self.deployment)
 
-        # One occurrence per day, attached to a capture from that day.
-        # Indices: 0 → day 0, captures_per_day → day 1, 2 * captures_per_day → day 2.
-        targets = [captures[0], captures[captures_per_day], captures[2 * captures_per_day]]
+        # One occurrence per day, picked at mid-day offsets (12h / 36h / 60h)
+        # so each target sits well inside its event's window, far from the
+        # exact 24h boundary where the cap's strict ``>`` semantics matter.
+        # Index-based selection (e.g. ``captures[len // 3]``) lands at exactly
+        # 24h offset, where Event 2 starts at 24h+10min (one capture past),
+        # so two of the three targets would otherwise share an event.
+        start_ts = captures[0].timestamp
+        targets = [
+            next(c for c in captures if c.timestamp >= start_ts + datetime.timedelta(hours=12)),
+            next(c for c in captures if c.timestamp >= start_ts + datetime.timedelta(hours=36)),
+            next(c for c in captures if c.timestamp >= start_ts + datetime.timedelta(hours=60)),
+        ]
         occurrences = []
         for capture in targets:
             detection = Detection.objects.create(
@@ -401,14 +409,13 @@ class TestImageGrouping(TestCase):
                 f"(expected {expected_event_id} from first detection's source_image)"
             )
 
-        # Realignment must also have moved occurrences across events, not just
-        # left them all on the (reused) day-0 event. With detections on captures
-        # 0, captures_per_day, and 2*captures_per_day, the 24h cap should put
-        # at least one occurrence on a non-day-0 event.
-        non_day0_events = Event.objects.filter(deployment=self.deployment).exclude(
-            pk=Occurrence.objects.filter(pk=occurrences[0].pk).values("event_id")[:1]
-        )
-        assert Occurrence.objects.filter(event__in=non_day0_events).count() >= 1
+        # Realignment must move all three occurrences onto distinct daily
+        # events. With targets at mid-day offsets, the three occurrences land
+        # on three different events — one on each day.
+        distinct_event_ids = {occ.event_id for occ in occurrences}
+        assert (
+            len(distinct_event_ids) == 3
+        ), f"expected 3 distinct event_ids across occurrences, got {distinct_event_ids}"
 
         # Each daily event's cached ``occurrences_count`` must match the live
         # computation that ``update_calculated_fields`` itself uses (which

--- a/ami/main/tests.py
+++ b/ami/main/tests.py
@@ -370,7 +370,7 @@ class TestImageGrouping(TestCase):
             detection = Detection.objects.create(
                 source_image=capture,
                 timestamp=capture.timestamp,
-                bbox=[0.1, 0.1, 0.2, 0.2],
+                bbox=[10, 10, 20, 20],
             )
             occurrence = Occurrence.objects.create(
                 event=mega_event,

--- a/ami/main/tests.py
+++ b/ami/main/tests.py
@@ -236,6 +236,38 @@ class TestImageGrouping(TestCase):
         for event in events:
             assert event.captures.count() == images_per_night
 
+    def test_continuous_monitoring_capped_at_24_hours(self):
+        """
+        A deployment that captures images continuously (no gap > max_time_gap)
+        should still be broken into daily events by the max_event_duration cap,
+        not coalesced into one multi-day event.
+        """
+        import pathlib
+        import uuid
+
+        start = datetime.datetime(2023, 4, 24, 3, 22, 38)
+        # 3 days of images every 10 minutes — no gap ever exceeds max_time_gap
+        interval = datetime.timedelta(minutes=10)
+        total_span = datetime.timedelta(days=3)
+        count = int(total_span / interval)
+        for i in range(count):
+            SourceImage.objects.create(
+                deployment=self.deployment,
+                timestamp=start + i * interval,
+                path=pathlib.Path("test") / f"{uuid.uuid4().hex[:8]}_continuous_{i}.jpg",
+            )
+
+        events = group_images_into_events(
+            deployment=self.deployment,
+            max_time_gap=datetime.timedelta(hours=2),
+            max_event_duration=datetime.timedelta(hours=24),
+        )
+
+        assert len(events) >= 3, f"expected at least 3 daily events, got {len(events)}"
+        for event in events:
+            duration = event.end - event.start
+            assert duration <= datetime.timedelta(hours=24), f"event {event.pk} spans {duration}, exceeds 24h cap"
+
     def test_pruning_empty_events(self):
         from ami.main.models import delete_empty_events
 

--- a/ami/utils/dates.py
+++ b/ami/utils/dates.py
@@ -112,9 +112,14 @@ def format_timedelta(duration: datetime.timedelta | None) -> str:
 def group_datetimes_by_gap(
     timestamps: list[datetime.datetime],
     max_time_gap=datetime.timedelta(minutes=120),
+    max_event_duration: datetime.timedelta | None = None,
 ) -> list[list[datetime.datetime]]:
     """
     Divide a list of timestamps into groups based on a maximum time gap.
+
+    When ``max_event_duration`` is set, a group is also split once it would
+    exceed that duration. This prevents continuous-monitoring deployments
+    (no quiet gap between nights) from producing a single multi-month group.
 
     >>> timestamps = [
     ...     datetime.datetime(2021, 1, 1, 0, 10, 0), # @TODO confirm the first gap is having an effect
@@ -145,6 +150,22 @@ def group_datetimes_by_gap(
     >>> result = group_datetimes_by_gap(timestamps, max_time_gap=datetime.timedelta(minutes=1))
     >>> len(result)
     10
+
+    Continuous-monitoring case: a long gap-free stream gets capped by
+    ``max_event_duration`` even when no gap exceeds ``max_time_gap``.
+
+    >>> continuous = [datetime.datetime(2021, 1, 1) + datetime.timedelta(minutes=5 * i) for i in range(24 * 12 * 3)]
+    >>> len(group_datetimes_by_gap(continuous, max_time_gap=datetime.timedelta(minutes=120)))
+    1
+    >>> groups = group_datetimes_by_gap(
+    ...     continuous,
+    ...     max_time_gap=datetime.timedelta(minutes=120),
+    ...     max_event_duration=datetime.timedelta(hours=24),
+    ... )
+    >>> len(groups)
+    3
+    >>> all((g[-1] - g[0]) <= datetime.timedelta(hours=24) for g in groups)
+    True
     """
     timestamps.sort()
     prev_timestamp: datetime.datetime | None = None
@@ -157,7 +178,12 @@ def group_datetimes_by_gap(
         else:
             delta = datetime.timedelta(0)
 
-        if delta >= max_time_gap:
+        split_by_gap = delta >= max_time_gap
+        split_by_duration = (
+            max_event_duration is not None and current_group and (timestamp - current_group[0]) > max_event_duration
+        )
+
+        if split_by_gap or split_by_duration:
             groups.append(current_group)
             current_group = []
 


### PR DESCRIPTION
## Summary

`group_images_into_events` currently splits images into events only when it sees a gap larger than `max_time_gap` (default 2h). For continuous-monitoring deployments (no nightly quiet period), the stream never has a 2h gap, so every image in the deployment coalesces into a single multi-month event.

Observed in production on deployment 489 (Camera 263): one "event" spanning **Apr 24 → Jul 23 2023 (90 days)** containing 355k source_images. The downstream UPDATE on `main_sourceimage.event_id` for this mega-event also caused stuck PG backends (the UPDATE touches 355k rows × 10 indexes).

## Fix

Add a `max_event_duration` kwarg to `group_datetimes_by_gap` and thread it through `group_images_into_events` with a default of **24 hours**. When set, a group is also split once its span would exceed the cap, even when no gap triggers a split. `None` disables the cap (backward compatible for existing callers of the utility).

Also removed the stale inline `# @TODO this event grouping needs testing. Still getting events over 24 hours` comment now that events over 24h are prevented by construction.

### Follow-up correctness fixes (commit `637afce2`)

The first round of this PR only handled the gap/duration split itself. Reviewing the regroup path against the production deployment surfaced two pre-existing data-correctness bugs that the cap reliably triggers, so they are addressed here rather than as separate PRs:

1. **`Occurrence.event_id` realignment.** Occurrences are bound to an event once at creation time (`Detection.associate_new_occurrence`, `Pipeline.save_results` both read `source_image.event`) and were never re-derived afterward. Without a refresh, a deployment regrouped under the 24h cap kept every occurrence pointing at its original (pre-cap) event regardless of when its detections actually fired, breaking every `Occurrence.event`-keyed query (the `occur_det_proj_evt` index, `Event.occurrences` related-name, the `event_ids=` filter chain at `models.py:4232–4477`). Now realigned via `Occurrence.event_id = first_detection.source_image.event_id`. The pre- and post-refresh event holders are unioned into `touched_event_pks` so `update_calculated_fields_for_events` covers both occurrence-losers and -gainers.

2. **Deployment-level cache refresh.** The async `regroup_events` task never went through `Deployment.save`'s calculated-fields refresh, so the deployment list (`occurrences_count`, `taxa_count`, `captures_count`, `detections_count`) showed pre-regroup numbers until the next save touched the deployment. Replaced the manual `events_count`-only update at the end of `group_images_into_events` with a full `deployment.update_calculated_fields(save=True)` call (which itself uses `update_calculated_fields=False` so it does not re-enter the regroup path).

## Test plan

- [x] Doctest in `ami/utils/dates.py` for the continuous-monitoring case: 3 days of 5-minute-interval timestamps with no gap > 120 min produces 1 group without the cap, 3 groups (each ≤24h) with `max_event_duration=24h`.
- [x] `TestImageGrouping.test_continuous_monitoring_capped_at_24_hours` — fresh grouping path, asserts exactly 3 daily events ≤24h.
- [x] `TestImageGrouping.test_regrouping_existing_long_event_refreshes_cached_fields` — re-grouping path, asserts cached `captures_count` per event is consistent post-regroup and no captures are orphaned.
- [x] `TestImageGrouping.test_regrouping_realigns_occurrence_event_id` — covers the detection→source_image→event chain post-regroup, plus per-event `occurrences_count` consistency against the live `get_occurrences_count` helper.
- [x] Existing `test_grouping` (3 discrete nights) unchanged — the cap only fires when the gap-based split fails to trigger.
- [x] Full local test pass: `ami.main.tests + ami.exports.tests + ami.ml.tests` → 249 tests, OK (2 skipped).
- [x] `python -m doctest ami/utils/dates.py` → 28 attempted, 0 failed.
- [x] `black` + `isort` + `flake8` + `pyupgrade` + `django-upgrade` pre-commit hooks pass.
- [ ] CI test run on merge target.

## How to verify post-deploy

After merging and deploying, run on a continuous-monitoring deployment with existing detections/occurrences (e.g. deployment 489) and check each of the three correctness layers in turn. Trigger the regroup via the admin `regroup_events` action, the `regroup_events` celery task, or `Deployment.save(regroup_async=False)`.

```python
import datetime
from django.db import models
from ami.main.models import Deployment, Event, SourceImage, Occurrence, Detection

dep = Deployment.objects.get(pk=<deployment_pk>)

# 1. Cap: no event spans > 24h.
over_cap = Event.objects.filter(
    deployment=dep,
    start__lt=models.F("end") - datetime.timedelta(hours=24),
).count()
assert over_cap == 0, f"{over_cap} events still exceed 24h"

# 2. Per-event captures_count: cached counter matches actual captures
#    (the original "stale cache on reused mega-event" bug).
for ev in Event.objects.filter(deployment=dep):
    actual = SourceImage.objects.filter(event=ev).count()
    assert ev.captures_count == actual, (
        f"event {ev.pk}: cached captures_count={ev.captures_count} actual={actual}"
    )

# 3. Occurrence.event_id realignment: every occurrence's event matches its
#    first detection's source_image.event. Sample a few; full pass on a
#    357k-image deployment is fine but takes a minute.
for occ in Occurrence.objects.filter(deployment=dep).order_by("?")[:200]:
    first = (
        Detection.objects.filter(occurrence=occ)
        .select_related("source_image")
        .order_by("source_image__timestamp")
        .first()
    )
    if first is None:
        continue
    assert occ.event_id == first.source_image.event_id, (
        f"occurrence {occ.pk}: stale event_id={occ.event_id} "
        f"(expected {first.source_image.event_id})"
    )

# 4. Deployment cache refresh: list-view counters reflect the regroup.
dep.refresh_from_db()
print(dep.events_count, dep.captures_count, dep.occurrences_count, dep.taxa_count)
# Expect: events_count ≈ days covered (was 1 mega-event), other counts
# unchanged in absolute terms (occurrences/taxa weren't added/removed,
# just re-bucketed across events).
```

UI spot-checks worth doing:

- **Sessions list / Events list**: each event should show a duration ≤ 24h, with non-zero `occurrences_count` and `taxa_count` distributed across the daily events (pre-regroup all the count was on the single mega-event).
- **Occurrence detail view**: the `event` link / breadcrumb should point at the daily event whose date matches the occurrence's first detection, not the original mega-event date.
- **Deployment list**: `occurrences_count` and `taxa_count` columns should match the project summary view (which queries Occurrence directly and is unaffected by caching).

## Staging verification

Validated on staging (commit `47c47e75`) against a prod-shaped Diopsis dataset.

- **Target**: Deployment 289 (`Camera 263 (90d clone)` on project 114 `Diopsis 90d Test Clone`) — 357,490 captures spanning 105 days, 99 events post-cap.
- **Cap behavior** (validated against an earlier `ad2ea6ff` run on this same dataset): pre-fix `regroup_events` produced 6 events including a single 90-day, 355,148-capture mega-event, and the celery task hit the 1h soft-time-limit. Post-fix produced 99 events, 0 exceeding 24h.
- **Occurrence.event_id realignment** (this run): seeded 5,000 synthetic Detections + Occurrences (`event=None`) via the new `seed_synthetic_occurrences` mgmt command (in `47c47e75`), then re-ran `group_images_into_events` with `max_event_duration=24h`.
  - Regroup completed in **88s** wallclock.
  - All 5,000 occurrences had their `event_id` populated correctly: `Detection.objects.filter(...).exclude(occurrence__event_id=F('source_image__event_id')).count() == 0`.
  - Occurrences distributed across exactly 11 distinct daily events (matching the 11-day window covered by the seeded captures).
  - 50-random-sample manual inspection: all `occurrence.event_id` values matched their earliest detection's `source_image.event_id` (per the deterministic ordering `(source_image__timestamp, source_image_id, pk)` added in `3b0d50cd`).
- **Cleanup**: `seed_synthetic_occurrences --deployment 289 --clean` removed all 5,000 synthetic rows. Staging restored to pre-test state.

The synthetic-seed path covers the `event_id=NULL → populated-correctly` branch. The `event_id=stale-pre-cap-id → repopulated-correctly` branch is covered by the local regression test `test_regrouping_realigns_occurrence_event_id`.

## Follow-ups (not in this PR)

- #906 — make `max_time_gap` (and by extension `max_event_duration`) configurable per project.
- #904 — session-grouping refactor with `use_existing` flag and removal of the `group_by` field.
- #1157 — expose session regrouping as a job stage with progress visibility.

This PR intentionally stays narrow: one new kwarg, one default, plus the data-correctness refreshes that the cap necessarily triggers on existing deployments. Can be rebased on top of #904 when that lands, or #904 can be rebased on top of this.

## Deployment notes

After merge + deploy, regrouping the affected deployment (e.g. via the admin `regroup_events` action or `Deployment.save(regroup_async=False)`) will split the existing multi-month event into daily events. Existing events with the same `group_by` date (the first day of the old mega-event) will be reused and pruned by `delete_empty_events` if emptied.

**Heads-up on existing >24h events.** Any deployment that today has events >24h — for any reason, not just the continuous-monitoring pathology — will get those events split on the next regroup. In practice everything we've seen >24h in production is itself an error state (the symptom this PR fixes, or unusual gap configurations), so this is the right behavior. Worth flagging if any project owner has a downstream report keyed on "1 event = 1 capture session" expecting multi-day events to stay intact. The audit warning at `audit_event_lengths` will stop firing for these deployments after the regroup, which is the intended end state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Event grouping now enforces a configurable maximum duration per event (default 24 hours), splitting long continuous streams into multiple events.

* **Bug Fixes**
  * Prevented stale event metadata after regrouping so event start/end and capture counts update correctly when captures move between events.
  * Realigned occurrence-to-event associations after regrouping so occurrences reflect the new grouping.
  * Refreshed deployment-level summary counts after regrouping so list views remain consistent.

* **Tests**
  * Added tests for multi-day stream segmentation, metadata refresh on regroup, and occurrence reassignment consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

